### PR TITLE
Correct: 오늘의 표현 용어 변경, JPA 기본값 설정

### DIFF
--- a/src/main/java/net/mureng/mureng/badge/entity/BadgeAccomplished.java
+++ b/src/main/java/net/mureng/mureng/badge/entity/BadgeAccomplished.java
@@ -28,7 +28,7 @@ public class BadgeAccomplished {
     private Badge badge;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Builder
     public BadgeAccomplished(BadgeAccomplishedPK id, LocalDateTime regDate) {

--- a/src/main/java/net/mureng/mureng/member/entity/Member.java
+++ b/src/main/java/net/mureng/mureng/member/entity/Member.java
@@ -23,8 +23,8 @@ public class Member {
     @Column(nullable = false)
     private String email;
 
-    @Column(name = "is_active", nullable = false, columnDefinition = "boolean default true")
-    private Boolean isActive;
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
 
     @Column(nullable = false, length = 8)
     private String nickname;
@@ -32,13 +32,13 @@ public class Member {
     private String image;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Column(name = "mod_date", nullable = false)
-    private LocalDateTime modDate;
+    private LocalDateTime modDate = LocalDateTime.now();
 
-    @Column(name = "mureng_count", nullable = false, columnDefinition = "int default 0")
-    private Long murengCount;
+    @Column(name = "mureng_count", nullable = false)
+    private Long murengCount = 0L;
 
     @OneToOne(mappedBy = "member")
     private MemberAttendance memberAttendance;

--- a/src/main/java/net/mureng/mureng/member/entity/MemberScrap.java
+++ b/src/main/java/net/mureng/mureng/member/entity/MemberScrap.java
@@ -29,7 +29,7 @@ public class MemberScrap {
     private TodayExpression todayExpression;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDate regDate;
+    private LocalDate regDate = LocalDate.now();
 
     @Builder
     public MemberScrap(MemberScrapPK id, LocalDate regDate) {

--- a/src/main/java/net/mureng/mureng/member/entity/MemberSetting.java
+++ b/src/main/java/net/mureng/mureng/member/entity/MemberSetting.java
@@ -25,8 +25,8 @@ public class MemberSetting {
     @Column(name = "daily_end_time", nullable = false)
     private LocalTime dailyEndTime;
 
-    @Column(name = "is_push_active", nullable = false, columnDefinition = "boolean default true")
-    private Boolean isPushActive;
+    @Column(name = "is_push_active", nullable = false)
+    private Boolean isPushActive = true;
 
     @Builder
     public MemberSetting(Long memberId, LocalTime dailyEndTime, Boolean isPushActive) {

--- a/src/main/java/net/mureng/mureng/question/entity/Question.java
+++ b/src/main/java/net/mureng/mureng/question/entity/Question.java
@@ -32,7 +32,7 @@ public class Question {
     private String koContent;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Builder
     public Question(Long questionId, Member memberId, String category, String content, String koContent, LocalDateTime regDate) {

--- a/src/main/java/net/mureng/mureng/question/entity/WordHint.java
+++ b/src/main/java/net/mureng/mureng/question/entity/WordHint.java
@@ -29,7 +29,7 @@ public class WordHint {
     private String meaning;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Builder
     public WordHint(Long hintId, Question questionId, String word, String meaning, LocalDateTime regDate) {

--- a/src/main/java/net/mureng/mureng/reply/entity/Reply.java
+++ b/src/main/java/net/mureng/mureng/reply/entity/Reply.java
@@ -33,17 +33,17 @@ public class Reply {
     @Column(nullable = false)
     private String image;
 
-    @Column(nullable = false, columnDefinition = "boolean default true")
-    private Boolean visible;
+    @Column(nullable = false)
+    private Boolean visible = true;
 
-    @Column(nullable = false, columnDefinition = "boolean default false")
-    private Boolean deleted;
+    @Column(nullable = false)
+    private Boolean deleted = false;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Column(name = "mod_date", nullable = false)
-    private LocalDateTime modDate;
+    private LocalDateTime modDate = LocalDateTime.now();
 
     @Builder
     public Reply(Long replyId, Member memberId, Question questionId, String content, String image, Boolean visible, Boolean deleted, LocalDateTime regDate, LocalDateTime modDate) {

--- a/src/main/java/net/mureng/mureng/reply/entity/ReplyLikes.java
+++ b/src/main/java/net/mureng/mureng/reply/entity/ReplyLikes.java
@@ -27,7 +27,7 @@ public class ReplyLikes {
     private Reply reply;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Builder
     public ReplyLikes(ReplyLikesPK id, LocalDateTime regDate) {

--- a/src/main/java/net/mureng/mureng/todayexpression/entity/TodayExpression.java
+++ b/src/main/java/net/mureng/mureng/todayexpression/entity/TodayExpression.java
@@ -27,22 +27,22 @@ public class TodayExpression {
     @Column(name = "expression_example")
     private String expressionExample;
 
-    @Column(name = "expression_meaning") // TODO expression_example_meaning 이 되어야 하는건 아닌지??
-    private String expressionMeaning;
+    @Column(name = "expression_example_meaning")
+    private String expressionExampleMeaning;
 
     @Column(name = "reg_date", nullable = false)
-    private LocalDateTime regDate;
+    private LocalDateTime regDate = LocalDateTime.now();
 
     @Column(name = "mod_date", nullable = false)
-    private LocalDateTime modDate;
+    private LocalDateTime modDate = LocalDateTime.now();
 
     @Builder
-    public TodayExpression(Long expId, String expression, String meaning, String expressionExample, String expressionMeaning, LocalDateTime regDate, LocalDateTime modDate) {
+    public TodayExpression(Long expId, String expression, String meaning, String expressionExample, String expressionExampleMeaning, LocalDateTime regDate, LocalDateTime modDate) {
         this.expId = expId;
         this.expression = expression;
         this.meaning = meaning;
         this.expressionExample = expressionExample;
-        this.expressionMeaning = expressionMeaning;
+        this.expressionExampleMeaning = expressionExampleMeaning;
         this.regDate = regDate;
         this.modDate = modDate;
     }

--- a/src/test/java/net/mureng/mureng/member/repository/MemberScrapRepositoryTest.java
+++ b/src/test/java/net/mureng/mureng/member/repository/MemberScrapRepositoryTest.java
@@ -4,7 +4,6 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import net.mureng.mureng.annotation.MurengDataTest;
 import net.mureng.mureng.member.entity.MemberScrap;
 import net.mureng.mureng.member.entity.MemberScrapPK;
-import net.mureng.mureng.member.repository.MemberScrapRepository;
 import net.mureng.mureng.todayexpression.entity.TodayExpression;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -74,11 +71,11 @@ public class MemberScrapRepositoryTest {
         assertEquals("test", todayExpressions.get(0).getExpression());
         assertEquals("테스트", todayExpressions.get(0).getMeaning());
         assertEquals("this is test.", todayExpressions.get(0).getExpressionExample());
-        assertEquals("이것은 테스트이다.", todayExpressions.get(0).getExpressionMeaning());
+        assertEquals("이것은 테스트이다.", todayExpressions.get(0).getExpressionExampleMeaning());
 
         assertEquals("test2", todayExpressions.get(1).getExpression());
         assertEquals("테스트2", todayExpressions.get(1).getMeaning());
         assertEquals("this is test2.", todayExpressions.get(1).getExpressionExample());
-        assertEquals("이것은 테스트2이다.", todayExpressions.get(1).getExpressionMeaning());
+        assertEquals("이것은 테스트2이다.", todayExpressions.get(1).getExpressionExampleMeaning());
     }
 }

--- a/src/test/resources/dbunit/entity/today_expression.xml
+++ b/src/test/resources/dbunit/entity/today_expression.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
     <today_expression exp_id="1" expression="test" meaning="테스트" expression_example="this is test."
-                      expression_meaning="이것은 테스트이다." mod_date="2020-10-14 17:11:10" reg_date="2020-10-14 17:11:09"/>
+                      expression_example_meaning="이것은 테스트이다." mod_date="2020-10-14 17:11:10" reg_date="2020-10-14 17:11:09"/>
     <today_expression exp_id="2" expression="test2" meaning="테스트2" expression_example="this is test2."
-                      expression_meaning="이것은 테스트2이다." mod_date="2020-10-15 17:11:10" reg_date="2020-10-15 17:11:09"/>
+                      expression_example_meaning="이것은 테스트2이다." mod_date="2020-10-15 17:11:10" reg_date="2020-10-15 17:11:09"/>
 </dataset>


### PR DESCRIPTION
형 말대로 오늘의 표현에서 사용하는 용어 변경했고, JPA 기본값 관련해서도  DDL(defaultDefinition)은 모두 제거하고, 엔티티 속성 값을 직접 설정하도록 했어!! 나중에 DDL로 설정할 필요가 있으면 그 때 다시 하는 게 좋을 거 같아서, 일단 깔끔하게 다 지웠어