### PR TITLE
Test: 웹요청 테스트 보완

### DIFF
--- a/src/test/java/net/mureng/mureng/jwt/JwtAuthenticationTest.java
+++ b/src/test/java/net/mureng/mureng/jwt/JwtAuthenticationTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class JwtAuthenticationTest {
@@ -18,6 +19,6 @@ public class JwtAuthenticationTest {
         String nickname = "Test";
         String token = jwtTokenProvider.createToken(email, nickname);
 
-        assertEquals(true, jwtTokenProvider.validateToken(token));
+        assertTrue(jwtTokenProvider.validateToken(token));
     }
 }

--- a/src/test/java/net/mureng/mureng/web/HomeControllerTest.java
+++ b/src/test/java/net/mureng/mureng/web/HomeControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-class HomeControllerTest extends AbstractControllerTest{
+class HomeControllerTest extends AbstractControllerTest {
 
     @Autowired
     private HomeController homeController;
@@ -37,6 +38,7 @@ class HomeControllerTest extends AbstractControllerTest{
         mockMvc.perform(
                 get("/api/test")
         ).andExpect(status().isForbidden());
+        // TODO 403 커스텀 응답 리턴
     }
 
     @Test
@@ -59,9 +61,10 @@ class HomeControllerTest extends AbstractControllerTest{
         given(userDetailsService.loadUserByUsername(eq(email))).willReturn(new UserDetailsImpl(member));
 
         mockMvc.perform(
-                get("/api/test")
-                .header("X-AUTH-TOKEN", token)
-        ).andExpect(status().isOk());
+                    get("/api/test")
+                    .header("X-AUTH-TOKEN", token)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"));
     }
 
 }


### PR DESCRIPTION
바디 데이터까지 검증할 수 있도록 테스트 보완했어!
추후에 403, 404 등 에러메시지에 대해서도 기존의 ApiResult 설계대로 응답 리턴해주려고 하는데, 이건 아마 ControllerAdvice 나 Filter 레벨에서 처리해줘야 할 것 같아.