### PR TITLE
[기능] swagger-ui 개편, JWT 인증 수단 추가

### DIFF
--- a/src/main/java/net/mureng/mureng/core/annotation/CurrentUser.java
+++ b/src/main/java/net/mureng/mureng/core/annotation/CurrentUser.java
@@ -1,6 +1,7 @@
 package net.mureng.mureng.core.annotation;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import springfox.documentation.annotations.ApiIgnore;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/net/mureng/mureng/core/config/SwaggerConfig.java
+++ b/src/main/java/net/mureng/mureng/core/config/SwaggerConfig.java
@@ -1,12 +1,20 @@
 package net.mureng.mureng.core.config;
 
+import net.mureng.mureng.core.annotation.CurrentUser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -14,8 +22,45 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .ignoredParameterTypes(CurrentUser.class)
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("net.mureng.mureng"))
-                .paths(PathSelectors.any()).build();
+                .paths(PathSelectors.any()).build()
+                .apiInfo(metaData())
+                .securityContexts(Collections.singletonList(securityContext()))
+                .securitySchemes(Collections.singletonList(apiKey()));
+    }
+
+    private ApiInfo metaData() {
+        return new ApiInfoBuilder()
+                .title("Mureng REST API")
+                .description("머렝 백엔드 REST API 문서")
+                .version("1.0")
+                .termsOfServiceUrl("Terms of service")
+                .contact(new Contact("hkpark, hwjoe", "https://github.com/YAPP-18th/Android-Team-1-Backend", "hygoogi@naver.com"))
+                .license("Apache License Version 2.0")
+                .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0")
+                .build();
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "X-AUTH-TOKEN", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return springfox
+                .documentation
+                .spi.service
+                .contexts
+                .SecurityContext
+                .builder()
+                .securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+    }
+
+    List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Collections.singletonList(new SecurityReference("JWT", authorizationScopes));
     }
 }

--- a/src/main/java/net/mureng/mureng/core/jwt/component/JwtCreator.java
+++ b/src/main/java/net/mureng/mureng/core/jwt/component/JwtCreator.java
@@ -16,7 +16,7 @@ import java.util.Date;
 public class JwtCreator {
     private final long TOKEN_VALID_MILISECOND = 1000l * 60 * 60 * 24; // 24 시간
 
-    @Value("spring.jwt.secret")
+    @Value("${spring.jwt.secret}")
     private String secretKey;
 
     @PostConstruct

--- a/src/main/java/net/mureng/mureng/core/jwt/component/JwtResolver.java
+++ b/src/main/java/net/mureng/mureng/core/jwt/component/JwtResolver.java
@@ -17,7 +17,7 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class JwtResolver {
 
-    @Value("spring.jwt.secret")
+    @Value("${spring.jwt.secret}")
     private String secretKey;
 
     private final UserDetailsService userDetailsService;

--- a/src/main/java/net/mureng/mureng/core/jwt/component/JwtValidator.java
+++ b/src/main/java/net/mureng/mureng/core/jwt/component/JwtValidator.java
@@ -15,7 +15,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtValidator {
 
-    @Value("spring.jwt.secret")
+    @Value("${spring.jwt.secret}")
     private String secretKey;
 
     @PostConstruct

--- a/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
+++ b/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
@@ -12,6 +12,7 @@ import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.reply.service.ReplyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;


### PR DESCRIPTION
# Swagger-UI 에서 JWT 인증하는 방법
![image](https://user-images.githubusercontent.com/36787678/118017579-c0ba5980-b391-11eb-89ee-99f6ad3c2e77.png)
![image](https://user-images.githubusercontent.com/36787678/118017653-d760b080-b391-11eb-85a3-b76fbe492d1a.png)
보이는 빈칸에 JWT를 입력하면 된다.

JWT를 가져오는 방법
1. /api/jwt 엔드포인트를 사용하여 JWT 취득
2. 미리 생성해둔 테스트용 JWT 사용 (보안상 노션을 통해 공유)
```
eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ... (나머지는 보안상 노션을 통해 공유)
```