### PR TITLE
[기능] 질문 조회하기

### DIFF
--- a/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
+++ b/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
@@ -2,23 +2,13 @@ package net.mureng.mureng.question.component;
 
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.component.EntityMapper;
-import net.mureng.mureng.member.dto.MemberDto;
-import net.mureng.mureng.member.entity.Member;
-import net.mureng.mureng.member.entity.MemberAttendance;
-import net.mureng.mureng.member.entity.MemberSetting;
 import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.dto.WordHintDto;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.entity.WordHint;
 import org.modelmapper.Converter;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,7 +36,8 @@ public class QuestionMapper extends EntityMapper {
     protected void initDtoToEntityMapping() {
         modelMapper.createTypeMap(QuestionDto.class, Question.class)
                 .addMappings(mapper -> mapper.skip(Question::setMember))
-                .addMappings(mapper -> mapper.skip(Question::setRegDate));
+                .addMappings(mapper -> mapper.skip(Question::setRegDate))
+                .addMappings(mapper -> mapper.skip(Question::setReplies));
     }
 
     public Question map(QuestionDto questionDto) {

--- a/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
+++ b/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
@@ -6,9 +6,11 @@ import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.dto.WordHintDto;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.entity.WordHint;
+import net.mureng.mureng.reply.entity.Reply;
 import org.modelmapper.Converter;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,9 +29,18 @@ public class QuestionMapper extends EntityMapper {
                     .map(wordHintMapper::map)
                     .collect(Collectors.toSet());
         };
+        final Converter<List<Reply>, Long> repliesCountConverter = context -> {
+            if (context == null)
+                return null;
+
+            return context.getSource().stream().count();
+        };
+
         modelMapper.createTypeMap(Question.class, QuestionDto.class)
                 .addMappings(mapper -> mapper.using(wordHintConverter)
-                        .map(Question::getWordHints, QuestionDto::setWordHints));
+                        .map(Question::getWordHints, QuestionDto::setWordHints))
+                .addMappings(mapper -> mapper.using(repliesCountConverter)
+                        .map(Question::getReplies, QuestionDto::setRepliesCount));
     }
 
     @Override

--- a/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
+++ b/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
@@ -3,11 +3,7 @@ package net.mureng.mureng.question.dto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
-import net.mureng.mureng.member.entity.Member;
-import net.mureng.mureng.question.entity.WordHint;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Set;
 
 @Builder
@@ -16,7 +12,7 @@ import java.util.Set;
 @AllArgsConstructor
 @ApiModel(value="질문 모델", description="질문을 나타내는 모델")
 public class QuestionDto {
-    @ApiModelProperty(value = "질문 기본키")
+    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
     private Long questionId;
 
     @ApiModelProperty(value = "카테고리")
@@ -30,4 +26,7 @@ public class QuestionDto {
 
     @ApiModelProperty(value = "연관된 단어 힌트들")
     private Set<WordHintDto> wordHints;
+
+    @ApiModelProperty(value = "작성된 답변 수")
+    private Long repliesCount;
 }

--- a/src/main/java/net/mureng/mureng/question/entity/Question.java
+++ b/src/main/java/net/mureng/mureng/question/entity/Question.java
@@ -2,9 +2,11 @@ package net.mureng.mureng.question.entity;
 
 import lombok.*;
 import net.mureng.mureng.member.entity.Member;
+import net.mureng.mureng.reply.entity.Reply;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,6 +40,10 @@ public class Question {
     @Builder.Default
     @OneToMany(mappedBy = "question", fetch = FetchType.EAGER)
     private Set<WordHint> wordHints = new HashSet<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "question")
+    private List<Reply> replies = new ArrayList<>();
 
     @Builder.Default
     @Column(name = "reg_date", nullable = false)

--- a/src/main/java/net/mureng/mureng/question/repository/QuestionRepository.java
+++ b/src/main/java/net/mureng/mureng/question/repository/QuestionRepository.java
@@ -1,11 +1,16 @@
 package net.mureng.mureng.question.repository;
 
 import net.mureng.mureng.question.entity.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findAllByMemberMemberId(Long memberId);
     boolean existsByQuestionIdAndMemberMemberId(Long questionId, Long memberId);
+    @Query("Select q from Question q order by q.replies.size desc")
+    Page<Question> findAllOrderByRepliesSizeDesc(Pageable page);
 }

--- a/src/main/java/net/mureng/mureng/question/repository/QuestionRepository.java
+++ b/src/main/java/net/mureng/mureng/question/repository/QuestionRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    List<Question> findAllByMemberMemberId(Long memberId);
+    List<Question> findAllByMemberMemberIdOrderByRegDateDesc(Long memberId);
     boolean existsByQuestionIdAndMemberMemberId(Long questionId, Long memberId);
     @Query("Select q from Question q order by q.replies.size desc")
     Page<Question> findAllOrderByRepliesSizeDesc(Pageable page);

--- a/src/main/java/net/mureng/mureng/question/service/QuestionService.java
+++ b/src/main/java/net/mureng/mureng/question/service/QuestionService.java
@@ -1,10 +1,12 @@
 package net.mureng.mureng.question.service;
 
 import lombok.RequiredArgsConstructor;
+import net.mureng.mureng.core.exception.BadRequestException;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.repository.QuestionRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,5 +29,12 @@ public class QuestionService {
     public boolean isAlreadyReplied(Long questionId, Long memberId) { return questionRepository.existsByQuestionIdAndMemberMemberId(questionId, memberId); }
 
     @Transactional(readOnly = true)
-    public Page<Question> getQuestionList(int page, int size) {return questionRepository.findAll(PageRequest.of(page, size)); }
+    public Page<Question> getQuestionList(int page, int size, String sort) {
+        if(sort.equals("popular"))
+            return questionRepository.findAllOrderByRepliesSizeDesc(PageRequest.of(page, size));
+        else if(sort.equals("newest"))
+            return questionRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "regDate")));
+        else
+            throw new BadRequestException("잘못된 요청입니다.");
+    }
 }

--- a/src/main/java/net/mureng/mureng/question/service/QuestionService.java
+++ b/src/main/java/net/mureng/mureng/question/service/QuestionService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
@@ -36,5 +38,10 @@ public class QuestionService {
             return questionRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "regDate")));
         else
             throw new BadRequestException("잘못된 요청입니다.");
+    }
+
+    @Transactional(readOnly = true)
+    public List<Question> getQuestionWrittenByMember(Long memberId){
+        return questionRepository.findAllByMemberMemberIdOrderByRegDateDesc(memberId);
     }
 }

--- a/src/main/java/net/mureng/mureng/question/service/QuestionService.java
+++ b/src/main/java/net/mureng/mureng/question/service/QuestionService.java
@@ -17,7 +17,7 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public Question getQuestionById(Long questionId){
-        return questionRepository.findById(questionId).orElseThrow();
+        return questionRepository.findById(questionId).orElseThrow(() -> new BadRequestException("존재하지 않는 질문입니다."));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/net/mureng/mureng/question/web/QuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/QuestionController.java
@@ -2,6 +2,7 @@ package net.mureng.mureng.question.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.dto.ApiResult;
 import net.mureng.mureng.question.component.QuestionMapper;
@@ -10,11 +11,9 @@ import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.service.QuestionService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,13 +25,12 @@ public class QuestionController {
     private final QuestionService questionService;
     private final QuestionMapper questionMapper;
 
-//    @ApiOperation(value = "질문에 대한 답변 목록 가져오기", notes = "질문에 대한 답변 목록을 가져옵니다.")
     @ApiOperation(value = "질문 목록 정렬 페이징 조회", notes = "질문 목록을 정렬 페이징해서 가져옵니다.")
     @GetMapping
     public ResponseEntity<ApiResult<List<QuestionDto>>> getQuestionList(
-            @RequestParam(required = false, defaultValue = "0") int page,
-            @RequestParam(required = false, defaultValue = "10") int size,
-            @RequestParam(required = false, defaultValue = "popular") String sort){
+            @ApiParam(value = "페이지 번호" ,required = false) @RequestParam(required = false, defaultValue = "0") int page,
+            @ApiParam(value = "한 페이지 크기" ,required = false) @RequestParam(required = false, defaultValue = "10") int size,
+            @ApiParam(value = "페이지 정렬 방식(popular, newest)" ,required = false) @RequestParam(required = false, defaultValue = "popular") String sort){
 
         Page<Question> questionList = questionService.getQuestionList(page, size, sort);
 
@@ -42,4 +40,16 @@ public class QuestionController {
                 .collect(Collectors.toList())
         ));
     }
+
+    @ApiOperation(value = "질문 조회", notes = "해당 질문을 가져옵니다.")
+    @GetMapping("/{questionId}")
+    public ResponseEntity<ApiResult<QuestionDto>> getQuestionById(
+            @ApiParam(value = "질문 id" ,required = true) @PathVariable @NotNull Long questionId){
+
+        return ResponseEntity.ok(ApiResult.ok(
+                questionMapper.map(questionService.getQuestionById(questionId))
+        ));
+    }
+
+
 }

--- a/src/main/java/net/mureng/mureng/question/web/QuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/QuestionController.java
@@ -27,13 +27,14 @@ public class QuestionController {
     private final QuestionMapper questionMapper;
 
 //    @ApiOperation(value = "질문에 대한 답변 목록 가져오기", notes = "질문에 대한 답변 목록을 가져옵니다.")
-    @ApiOperation(value = "질문 목록 가져오기", notes = "질문 목록 가져오기")
+    @ApiOperation(value = "질문 목록 정렬 페이징 조회", notes = "질문 목록을 정렬 페이징해서 가져옵니다.")
     @GetMapping
     public ResponseEntity<ApiResult<List<QuestionDto>>> getQuestionList(
             @RequestParam(required = false, defaultValue = "0") int page,
-            @RequestParam(required = false, defaultValue = "10") int size ){
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "popular") String sort){
 
-        Page<Question> questionList = questionService.getQuestionList(page, size);
+        Page<Question> questionList = questionService.getQuestionList(page, size, sort);
 
         return ResponseEntity.ok(ApiResult.ok(
                 questionList.stream()

--- a/src/main/java/net/mureng/mureng/question/web/QuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/QuestionController.java
@@ -4,7 +4,9 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiResult;
+import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.component.QuestionMapper;
 import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.entity.Question;
@@ -48,6 +50,18 @@ public class QuestionController {
 
         return ResponseEntity.ok(ApiResult.ok(
                 questionMapper.map(questionService.getQuestionById(questionId))
+        ));
+    }
+
+    @ApiOperation(value = "내가 만든 질문 목록 조회", notes = "해당 사용자가 만든 질문 목록을 가져옵니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<List<QuestionDto>>> getQuestionWrittenByMe(@CurrentUser Member member){
+        List<Question> questionList =  questionService.getQuestionWrittenByMember(member.getMemberId());
+
+        return ResponseEntity.ok(ApiResult.ok(
+                questionList.stream()
+                .map(questionMapper::map)
+                .collect(Collectors.toList())
         ));
     }
 

--- a/src/test/java/net/mureng/mureng/question/component/QuestionMapperTest.java
+++ b/src/test/java/net/mureng/mureng/question/component/QuestionMapperTest.java
@@ -1,18 +1,22 @@
 package net.mureng.mureng.question.component;
 
+import net.mureng.mureng.common.EntityCreator;
 import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.dto.WordHintDto;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.entity.WordHint;
+import net.mureng.mureng.reply.entity.Reply;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 class QuestionMapperTest {
@@ -33,6 +37,8 @@ class QuestionMapperTest {
             .meaning("사과")
             .build();
 
+    private final List<Reply> replies = Arrays.asList(EntityCreator.createReplyEntity(), EntityCreator.createReplyEntity());
+
     private final Question question = Question.builder()
             .questionId(1L)
             .member(Member.builder().build())
@@ -41,6 +47,7 @@ class QuestionMapperTest {
             .koContent("이것은 한글 내용입니다.")
             .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
             .wordHints(Set.of(wordHint))
+            .replies(replies)
             .build();
 
     private final QuestionDto questionDto = QuestionDto.builder()
@@ -49,6 +56,7 @@ class QuestionMapperTest {
             .content("This is english content.")
             .koContent("이것은 한글 내용입니다.")
             .wordHints(Set.of(wordHintDto))
+            .repliesCount(2L)
             .build();
 
     @Test
@@ -56,9 +64,10 @@ class QuestionMapperTest {
         QuestionDto mappedDto = questionMapper.map(question);
         assertEquals(questionDto.getQuestionId(), mappedDto.getQuestionId());
         assertEquals(questionDto.getCategory(), mappedDto.getCategory());
-        assertEquals(questionDto.getCategory(), mappedDto.getCategory());
+        assertEquals(questionDto.getContent(), mappedDto.getContent());
         assertEquals(questionDto.getKoContent(), mappedDto.getKoContent());
         assertEquals(questionDto.getWordHints().size(), mappedDto.getWordHints().size());
+        assertEquals(questionDto.getRepliesCount(), mappedDto.getRepliesCount());
     }
 
     @Test
@@ -66,7 +75,7 @@ class QuestionMapperTest {
         Question mappedEntity = questionMapper.map(questionDto);
         assertEquals(question.getQuestionId(), mappedEntity.getQuestionId());
         assertEquals(question.getCategory(), mappedEntity.getCategory());
-        assertEquals(question.getCategory(), mappedEntity.getCategory());
+        assertEquals(question.getContent(), mappedEntity.getContent());
         assertEquals(question.getKoContent(), mappedEntity.getKoContent());
         assertEquals(question.getWordHints().size(), mappedEntity.getWordHints().size());
     }

--- a/src/test/java/net/mureng/mureng/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/net/mureng/mureng/question/repository/QuestionRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -19,7 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @DatabaseSetup({
         "classpath:dbunit/entity/member.xml",
         "classpath:dbunit/entity/question.xml",
-        "classpath:dbunit/entity/word_hint.xml"
+        "classpath:dbunit/entity/word_hint.xml",
+        "classpath:dbunit/entity/reply.xml"
 })
 public class QuestionRepositoryTest {
 
@@ -72,21 +74,37 @@ public class QuestionRepositoryTest {
     }
 
     @Test
-    public void 질문_목록_페이징_테스트(){
+    public void 질문_목록_인기순_페이징_조회_테스트(){
         int page = 0;
-        int size = 2;
+        int size = 3;
         int id = 1;
 
-        Page<Question> questionPageList = questionRepository.findAll(PageRequest.of(page, size));
-        List<Question> questionList = questionPageList.getContent();
+        Page<Question> questionPage = questionRepository.findAllOrderByRepliesSizeDesc(PageRequest.of(page, size));
+        List<Question> questionList = questionPage.getContent();
 
-        assertEquals(2, questionPageList.getTotalPages());
-        assertEquals(2, questionList.size());
+        assertEquals(3, questionPage.getNumberOfElements());
+        assertEquals(3, questionList.size());
 
         for(Question question : questionList){
             assertEquals(id++, question.getQuestionId());
         }
+    }
 
+    @Test
+    public void 질문_목록_최신순_페이징_조회_테스트(){
+        int page = 0;
+        int size = 3;
+        int id = 3;
+
+        Page<Question> questionPage = questionRepository.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "regDate")));
+        List<Question> questionList = questionPage.getContent();
+
+        assertEquals(3, questionPage.getNumberOfElements());
+        assertEquals(3, questionList.size());
+
+        for(Question question : questionList){
+            assertEquals(id--, question.getQuestionId());
+        }
     }
 
 }

--- a/src/test/java/net/mureng/mureng/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/net/mureng/mureng/question/repository/QuestionRepositoryTest.java
@@ -48,17 +48,17 @@ public class QuestionRepositoryTest {
 
     @Test
     public void 멤버로_질문_목록_조회(){
-        List<Question> questions = questionRepository.findAllByMemberMemberId(MEMBER_ID);
+        List<Question> questions = questionRepository.findAllByMemberMemberIdOrderByRegDateDesc(MEMBER_ID);
 
         assertEquals(2, questions.size());
 
         assertEquals(MEMBER_ID, questions.get(0).getMember().getMemberId());
-        assertEquals("what is your favorite color?", questions.get(0).getContent());
-        assertEquals("당신이 가장 좋아하는 색은 무엇인가요?", questions.get(0).getKoContent());
+        assertEquals("How did you feel when you first heard the mureng?", questions.get(0).getContent());
+        assertEquals("머렝을 처음 들었을 때 어떤 느낌이 들었나요?", questions.get(0).getKoContent());
 
         assertEquals(MEMBER_ID, questions.get(1).getMember().getMemberId());
-        assertEquals("How did you feel when you first heard the mureng?", questions.get(1).getContent());
-        assertEquals("머렝을 처음 들었을 때 어떤 느낌이 들었나요?", questions.get(1).getKoContent());
+        assertEquals("what is your favorite color?", questions.get(1).getContent());
+        assertEquals("당신이 가장 좋아하는 색은 무엇인가요?", questions.get(1).getKoContent());
     }
 
     @Test
@@ -106,5 +106,4 @@ public class QuestionRepositoryTest {
             assertEquals(id--, question.getQuestionId());
         }
     }
-
 }

--- a/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
+++ b/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
@@ -6,6 +6,8 @@ import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.service.QuestionService;
 import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.web.AbstractControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
@@ -26,60 +28,83 @@ public class QuestionControllerTest extends AbstractControllerTest {
     @MockBean
     private QuestionService questionService;
 
-    @Test
-    @WithMockMurengUser
-    public void 질문_목록_인기순_페이징_조회_테스트() throws Exception {
-        int page = 0;
-        int size = 2;
-        List<Reply> replies = new ArrayList<>();
-        replies.add(EntityCreator.createReplyEntity());
-        replies.add(EntityCreator.createReplyEntity());
+    private static final Long QUESTION_ID = 1L;
 
-        Question popularQuestion = EntityCreator.createQuestionEntity();
-        popularQuestion.setQuestionId(2L);
-        popularQuestion.setReplies(replies);
+    @Nested
+    @DisplayName("정렬 페이징 질문 목록 조회")
+    public class getSortedQuestionList {
+        @Test
+        @WithMockMurengUser
+        public void 질문_목록_인기순_페이징_조회_테스트() throws Exception {
+            int page = 0;
+            int size = 2;
+            List<Reply> replies = new ArrayList<>();
+            replies.add(EntityCreator.createReplyEntity());
+            replies.add(EntityCreator.createReplyEntity());
 
-        List<Question> questionList = new ArrayList<>();
-        questionList.add(popularQuestion);
-        questionList.add(EntityCreator.createQuestionEntity());
+            Question popularQuestion = EntityCreator.createQuestionEntity();
+            popularQuestion.setQuestionId(2L);
+            popularQuestion.setReplies(replies);
 
-        Page<Question> questionPage = new PageImpl<>(questionList);
+            List<Question> questionList = new ArrayList<>();
+            questionList.add(popularQuestion);
+            questionList.add(EntityCreator.createQuestionEntity());
 
-        given(questionService.getQuestionList(eq(page), eq(size), eq("popular"))).willReturn(questionPage);
+            Page<Question> questionPage = new PageImpl<>(questionList);
 
-        mockMvc.perform(
-                get("/api/questions?page=0&size=2&sort=popular")
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
-                .andDo(print());
+            given(questionService.getQuestionList(eq(page), eq(size), eq("popular"))).willReturn(questionPage);
+
+            mockMvc.perform(
+                    get("/api/questions?page=0&size=2&sort=popular")
+            ).andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
+                    .andDo(print());
+        }
+
+        @Test
+        @WithMockMurengUser
+        public void 질문_목록_최신순_페이징_조회_테스트() throws Exception {
+            int page = 0;
+            int size = 2;
+
+            Question popularQuestion = EntityCreator.createQuestionEntity();
+            popularQuestion.setQuestionId(2L);
+            popularQuestion.setRegDate(LocalDateTime.parse("2020-10-11T12:00:00"));
+
+            List<Question> questionList = new ArrayList<>();
+            questionList.add(popularQuestion);
+            questionList.add(EntityCreator.createQuestionEntity());
+
+            Page<Question> questionPage = new PageImpl<>(questionList);
+
+            given(questionService.getQuestionList(eq(page), eq(size), eq("newest"))).willReturn(questionPage);
+
+            mockMvc.perform(
+                    get("/api/questions?page=0&size=2&sort=newest")
+            ).andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
+                    .andDo(print());
+        }
     }
 
     @Test
     @WithMockMurengUser
-    public void 질문_목록_최신순_페이징_조회_테스트() throws Exception {
-        int page = 0;
-        int size = 2;
+    public void 질문_아이디_조회_테스트() throws Exception {
+        Question question = EntityCreator.createQuestionEntity();
 
-        Question popularQuestion = EntityCreator.createQuestionEntity();
-        popularQuestion.setQuestionId(2L);
-        popularQuestion.setRegDate(LocalDateTime.parse("2020-10-11T12:00:00"));
-
-        List<Question> questionList = new ArrayList<>();
-        questionList.add(popularQuestion);
-        questionList.add(EntityCreator.createQuestionEntity());
-
-        Page<Question> questionPage = new PageImpl<>(questionList);
-
-        given(questionService.getQuestionList(eq(page), eq(size), eq("newest"))).willReturn(questionPage);
+        given(questionService.getQuestionById(eq(QUESTION_ID))).willReturn(question);
 
         mockMvc.perform(
-                get("/api/questions?page=0&size=2&sort=newest")
+                get("/api/questions/1")
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.questionId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("This is english content."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.koContent").value("이것은 한글 내용입니다."))
                 .andDo(print());
     }
 }

--- a/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
+++ b/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
@@ -4,6 +4,7 @@ import net.mureng.mureng.annotation.WithMockMurengUser;
 import net.mureng.mureng.common.EntityCreator;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.service.QuestionService;
+import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.web.AbstractControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,23 +28,57 @@ public class QuestionControllerTest extends AbstractControllerTest {
 
     @Test
     @WithMockMurengUser
-    public void 질문_목록_페이징_조회_테스트() throws Exception {
+    public void 질문_목록_인기순_페이징_조회_테스트() throws Exception {
         int page = 0;
         int size = 2;
+        List<Reply> replies = new ArrayList<>();
+        replies.add(EntityCreator.createReplyEntity());
+        replies.add(EntityCreator.createReplyEntity());
+
+        Question popularQuestion = EntityCreator.createQuestionEntity();
+        popularQuestion.setQuestionId(2L);
+        popularQuestion.setReplies(replies);
 
         List<Question> questionList = new ArrayList<>();
-        questionList.add(EntityCreator.createQuestionEntity());
+        questionList.add(popularQuestion);
         questionList.add(EntityCreator.createQuestionEntity());
 
         Page<Question> questionPage = new PageImpl<>(questionList);
 
-        given(questionService.getQuestionList(eq(page), eq(size))).willReturn(questionPage);
+        given(questionService.getQuestionList(eq(page), eq(size), eq("popular"))).willReturn(questionPage);
 
         mockMvc.perform(
-                get("/api/questions?page=0&size=2")
+                get("/api/questions?page=0&size=2&sort=popular")
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 질문_목록_최신순_페이징_조회_테스트() throws Exception {
+        int page = 0;
+        int size = 2;
+
+        Question popularQuestion = EntityCreator.createQuestionEntity();
+        popularQuestion.setQuestionId(2L);
+        popularQuestion.setRegDate(LocalDateTime.parse("2020-10-11T12:00:00"));
+
+        List<Question> questionList = new ArrayList<>();
+        questionList.add(popularQuestion);
+        questionList.add(EntityCreator.createQuestionEntity());
+
+        Page<Question> questionPage = new PageImpl<>(questionList);
+
+        given(questionService.getQuestionList(eq(page), eq(size), eq("newest"))).willReturn(questionPage);
+
+        mockMvc.perform(
+                get("/api/questions?page=0&size=2&sort=newest")
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].questionId").value(2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].questionId").value(1))
                 .andDo(print());
     }

--- a/src/test/resources/dbunit/entity/question.xml
+++ b/src/test/resources/dbunit/entity/question.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
     <question question_id="1" member_id="1" content="what is your favorite color?" ko_content="당신이 가장 좋아하는 색은 무엇인가요?" reg_date="2020-10-14 17:11:09"/>
-    <question question_id="2" member_id="1" content="How did you feel when you first heard the mureng?" ko_content="머렝을 처음 들었을 때 어떤 느낌이 들었나요?" reg_date="2020-10-15 17:11:09"/>
-    <question question_id="3" member_id="2" content="Which of the four seasons do you like best?" ko_content="사계절 중 어떤 계절을 가장 좋아하시나요?" reg_date="2020-10-15 17:11:09"/>
+    <question question_id="2" member_id="1" content="How did you feel when you first heard the mureng?" ko_content="머렝을 처음 들었을 때 어떤 느낌이 들었나요?" reg_date="2020-10-15 17:11:19"/>
+    <question question_id="3" member_id="2" content="Which of the four seasons do you like best?" ko_content="사계절 중 어떤 계절을 가장 좋아하시나요?" reg_date="2020-10-15 17:11:29"/>
 </dataset>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/30318917/118280008-be2d4080-b506-11eb-922b-3cab3baefb0f.png)

#63
/api/questions/member/{memberId} - 사용자가 답변한 질문 목록 조회

일단 이슈탭에서 해야할 거 4개 중에 3개는 다 했어!! 그 과정에서 QuestionDto에 RepliesCount 변수를 추가했고!!
근데 이미지처럼 기록 탭에서 사용자가 답변한 질문 목록을 조회할 땐, 답변이랑 같이 딸려서 나와야 하는데, 어떻게 해야하지??
형이 하고 있는 question-replies가 혹시 이건가??