### PR TITLE
[보완] 객체 매핑 로직 modelmapper -> mapstruct으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'org.modelmapper:modelmapper:2.4.2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
@@ -38,6 +37,8 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.3.5'
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springframework.security:spring-security-test'
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 test {

--- a/src/main/java/net/mureng/mureng/core/component/EntityMapper.java
+++ b/src/main/java/net/mureng/mureng/core/component/EntityMapper.java
@@ -1,23 +1,8 @@
 package net.mureng.mureng.core.component;
 
-import net.mureng.mureng.question.dto.QuestionDto;
-import net.mureng.mureng.question.entity.Question;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
+import org.mapstruct.factory.Mappers;
 
-public abstract class EntityMapper {
-    protected final ModelMapper modelMapper = new ModelMapper();
-
-    protected EntityMapper() {
-        modelMapper.getConfiguration()
-                .setMatchingStrategy(MatchingStrategies.STANDARD);
-
-        initEntityToDtoMapping();
-        initDtoToEntityMapping();
-
-        modelMapper.validate();
-    }
-
-    protected abstract void initEntityToDtoMapping();
-    protected abstract void initDtoToEntityMapping();
+public interface EntityMapper<ENTITY, DTO> {
+    DTO toDto(ENTITY entity);
+    ENTITY toEntity(DTO dto);
 }

--- a/src/main/java/net/mureng/mureng/member/component/MemberMapper.java
+++ b/src/main/java/net/mureng/mureng/member/component/MemberMapper.java
@@ -3,41 +3,28 @@ package net.mureng.mureng.member.component;
 import net.mureng.mureng.core.component.EntityMapper;
 import net.mureng.mureng.member.dto.MemberDto;
 import net.mureng.mureng.member.entity.Member;
-import net.mureng.mureng.member.entity.MemberAttendance;
-import net.mureng.mureng.member.entity.MemberSetting;
-import org.modelmapper.Converter;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-@Component
-public class MemberMapper extends EntityMapper {
-    protected void initEntityToDtoMapping() {
-        modelMapper.createTypeMap(Member.class, MemberDto.class)
-                .addMapping(src -> src.getMemberAttendance().getAttendanceCount(), MemberDto::setAttendanceCount)
-                .addMapping(src -> src.getMemberAttendance().getLastAttendanceDate(), MemberDto::setLastAttendanceDate)
-                .addMapping(src -> src.getMemberSetting().isPushActive(), MemberDto::setPushActive);
-    }
+@Mapper(componentModel = "spring", imports = DateTimeFormatter.class)
+public interface MemberMapper extends EntityMapper<Member, MemberDto> {
+    @Override
+    @Mapping(target = "attendanceCount", expression = "java(member.getMemberAttendance().getAttendanceCount())")
+    @Mapping(target = "lastAttendanceDate", expression = "java(member.getMemberAttendance().getLastAttendanceDate()" +
+            ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")) )")
+    @Mapping(target = "pushActive", expression = "java(member.getMemberSetting().isPushActive())")
+    MemberDto.ReadOnly toDto(Member member);
 
-    protected void initDtoToEntityMapping() {
-        modelMapper.createTypeMap(MemberDto.class, Member.class)
-                .addMappings(mapper -> mapper.skip(Member::setMemberAttendance))
-                .addMappings(mapper -> mapper.skip(Member::setMemberSetting))
-                .addMappings(mapper -> mapper.skip(Member::setMurengCount))
-                .addMappings(mapper -> mapper.skip(Member::setRegDate))
-                .addMappings(mapper -> mapper.skip(Member::setModDate))
-                .addMappings(mapper -> mapper.skip(Member::setActive));
-    }
-
-    public Member map(MemberDto memberDto) {
-        return modelMapper.map(memberDto, Member.class);
-    }
-
-    public MemberDto map(Member member) {
-        return modelMapper.map(member, MemberDto.class);
-    }
+    @Override
+    @Mapping(target = "memberId", ignore = true)
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "murengCount", ignore = true)
+    @Mapping(target = "memberSetting", ignore = true)
+    @Mapping(target = "memberAttendance", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    @Mapping(target = "modDate", ignore = true)
+    Member toEntity(MemberDto memberDto);
 }

--- a/src/main/java/net/mureng/mureng/member/dto/MemberDto.java
+++ b/src/main/java/net/mureng/mureng/member/dto/MemberDto.java
@@ -4,44 +4,52 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import net.mureng.mureng.core.validation.annotation.DateFormat;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
-@Builder
+@SuperBuilder
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel(value="회원 모델", description="회원을 나타내는 모델")
 public class MemberDto {
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private Long memberId;
-
     @NotEmpty
-    @ApiModelProperty(value = "회원 식별값")
+    @ApiModelProperty(value = "회원 식별값", required = true)
     private String identifier;
 
     @Email
-    @ApiModelProperty(value = "이메일 주소")
+    @ApiModelProperty(value = "이메일 주소", required = true)
     private String email;
 
     @NotEmpty
-    @ApiModelProperty(value = "닉네임")
+    @ApiModelProperty(value = "닉네임", required = true)
     private String nickname;
 
     @ApiModelProperty(value = "프로필 이미지 경로")
     private String image;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private int murengCount;
+    @SuperBuilder
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value="회원 읽기 모델", description="읽기 전용 회원 모델")
+    public static class ReadOnly extends MemberDto {
+        @ApiModelProperty(value = "회원 고유 아이디", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private Long memberId;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private int attendanceCount;
+        @ApiModelProperty(value = "머렝 개수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private int murengCount;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private String lastAttendanceDate;
+        @ApiModelProperty(value = "출석 일수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private int attendanceCount;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private boolean isPushActive;
+        @ApiModelProperty(value = "마지막 출석 날짜", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private String lastAttendanceDate;
+
+        @ApiModelProperty(value = "푸쉬 알림 여부", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private boolean isPushActive;
+    }
 }

--- a/src/main/java/net/mureng/mureng/member/web/MemberController.java
+++ b/src/main/java/net/mureng/mureng/member/web/MemberController.java
@@ -33,12 +33,12 @@ public class MemberController {
 
     @ApiOperation(value = "신규 회원 가입", notes = "신규 회원가입입니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResult<MemberDto>> signup(
+    public ResponseEntity<ApiResult<MemberDto.ReadOnly>> signup(
             @ApiParam(value = "신규 회원 정보", required = true)
             @RequestBody @Valid MemberDto memberDto) {
 
-        Member newMember = memberMapper.map(memberDto);
-        return ResponseEntity.ok(ApiResult.ok(memberMapper.map(
+        Member newMember = memberMapper.toEntity(memberDto);
+        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(
                 memberSignupService.signup(newMember)
         )));
     }

--- a/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
+++ b/src/main/java/net/mureng/mureng/question/component/QuestionMapper.java
@@ -1,61 +1,27 @@
 package net.mureng.mureng.question.component;
 
-import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.component.EntityMapper;
+import net.mureng.mureng.member.dto.MemberDto;
+import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.dto.QuestionDto;
-import net.mureng.mureng.question.dto.WordHintDto;
 import net.mureng.mureng.question.entity.Question;
-import net.mureng.mureng.question.entity.WordHint;
-import net.mureng.mureng.reply.entity.Reply;
-import org.modelmapper.Converter;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
 
-@Component
-@RequiredArgsConstructor
-public class QuestionMapper extends EntityMapper {
-    private final WordHintMapper wordHintMapper;
+@Mapper(componentModel = "spring", uses = { WordHintMapper.class })
+public interface QuestionMapper extends EntityMapper<Question, QuestionDto> {
+    @Override
+    @Mapping(target = "repliesCount", expression = "java(question.getReplies().size())")
+    QuestionDto.ReadOnly toDto(Question question);
 
     @Override
-    protected void initEntityToDtoMapping() {
-        final Converter<Set<WordHint>, Set<WordHintDto>> wordHintConverter = context -> {
-            if (context == null)
-                return null;
-
-            return context.getSource().stream()
-                    .map(wordHintMapper::map)
-                    .collect(Collectors.toSet());
-        };
-        final Converter<List<Reply>, Long> repliesCountConverter = context -> {
-            if (context == null)
-                return null;
-
-            return context.getSource().stream().count();
-        };
-
-        modelMapper.createTypeMap(Question.class, QuestionDto.class)
-                .addMappings(mapper -> mapper.using(wordHintConverter)
-                        .map(Question::getWordHints, QuestionDto::setWordHints))
-                .addMappings(mapper -> mapper.using(repliesCountConverter)
-                        .map(Question::getReplies, QuestionDto::setRepliesCount));
-    }
-
-    @Override
-    protected void initDtoToEntityMapping() {
-        modelMapper.createTypeMap(QuestionDto.class, Question.class)
-                .addMappings(mapper -> mapper.skip(Question::setMember))
-                .addMappings(mapper -> mapper.skip(Question::setRegDate))
-                .addMappings(mapper -> mapper.skip(Question::setReplies));
-    }
-
-    public Question map(QuestionDto questionDto) {
-        return modelMapper.map(questionDto, Question.class);
-    }
-
-    public QuestionDto map(Question question) {
-        return modelMapper.map(question, QuestionDto.class);
-    }
+    @Mapping(target = "questionId", ignore = true)
+    @Mapping(target = "member", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    @Mapping(target = "replies", ignore = true)
+    @Mapping(target = "wordHints", ignore = true)
+    Question toEntity(QuestionDto questionDto);
 }

--- a/src/main/java/net/mureng/mureng/question/component/WordHintMapper.java
+++ b/src/main/java/net/mureng/mureng/question/component/WordHintMapper.java
@@ -1,31 +1,26 @@
 package net.mureng.mureng.question.component;
 
 import net.mureng.mureng.core.component.EntityMapper;
+import net.mureng.mureng.member.dto.MemberDto;
+import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.dto.WordHintDto;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.entity.WordHint;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-@Component
-public class WordHintMapper extends EntityMapper {
+import java.time.format.DateTimeFormatter;
+
+@Mapper(componentModel = "spring")
+public interface WordHintMapper extends EntityMapper<WordHint, WordHintDto> {
     @Override
-    protected void initEntityToDtoMapping() {
-        modelMapper.createTypeMap(WordHint.class, WordHintDto.class);
-    }
+    WordHintDto.ReadOnly toDto(WordHint wordHint);
 
     @Override
-    protected void initDtoToEntityMapping() {
-        modelMapper.createTypeMap(WordHintDto.class, WordHint.class)
-                .addMappings(mapper -> mapper.skip(WordHint::setQuestion))
-                .addMappings(mapper -> mapper.skip(WordHint::setRegDate));
-    }
-
-    public WordHint map(WordHintDto questionDto) {
-        return modelMapper.map(questionDto, WordHint.class);
-    }
-
-    public WordHintDto map(WordHint question) {
-        return modelMapper.map(question, WordHintDto.class);
-    }
+    @Mapping(target = "hintId", ignore = true)
+    @Mapping(target = "question", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    WordHint toEntity(WordHintDto wordHintDto);
 }

--- a/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
+++ b/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
@@ -3,30 +3,40 @@ package net.mureng.mureng.question.dto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.Set;
 
-@Builder
+@SuperBuilder
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel(value="질문 모델", description="질문을 나타내는 모델")
 public class QuestionDto {
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private Long questionId;
-
     @ApiModelProperty(value = "카테고리")
     private String category;
 
-    @ApiModelProperty(value = "영문 내용")
+    @NotEmpty
+    @ApiModelProperty(value = "영문 내용", required = true)
     private String content;
 
     @ApiModelProperty(value = "한글 내용")
     private String koContent;
 
-    @ApiModelProperty(value = "연관된 단어 힌트들")
-    private Set<WordHintDto> wordHints;
+    @SuperBuilder
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value="질문 읽기 모델", description="질문을 나타내는 읽기 모델")
+    public static class ReadOnly extends QuestionDto {
+        @ApiModelProperty(value = "질문 기본 키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private Long questionId;
 
-    @ApiModelProperty(value = "작성된 답변 수")
-    private Long repliesCount;
+        @ApiModelProperty(value = "연관된 단어 힌트들", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private Set<WordHintDto.ReadOnly> wordHints;
+
+        @ApiModelProperty(value = "작성된 답변 수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private int repliesCount;
+    }
 }

--- a/src/main/java/net/mureng/mureng/question/dto/WordHintDto.java
+++ b/src/main/java/net/mureng/mureng/question/dto/WordHintDto.java
@@ -3,6 +3,7 @@ package net.mureng.mureng.question.dto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import net.mureng.mureng.question.entity.Question;
 
 import javax.persistence.Column;
@@ -10,19 +11,25 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.time.LocalDateTime;
 
-@Builder
-@Getter
-@Setter
+@SuperBuilder
+@Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel(value="단어 힌트 모델", description="단어 힌트를 나타내는 모델")
 public class WordHintDto {
-    @ApiModelProperty(value = "단어 힌트 기본키")
-    private Long hintId;
-
     @ApiModelProperty(value = "단어")
     private String word;
 
     @ApiModelProperty(value = "뜻")
     private String meaning;
+
+    @SuperBuilder
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value="단어 힌트 읽기 모델", description="단어 힌트를 나타내는 읽기 모델")
+    public static class ReadOnly extends WordHintDto {
+        @ApiModelProperty(value = "단어 힌트 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private Long hintId;
+    }
 }

--- a/src/main/java/net/mureng/mureng/question/web/QuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/QuestionController.java
@@ -6,7 +6,6 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiPageRequest;
-import net.mureng.mureng.core.dto.ApiPageResult;
 import net.mureng.mureng.core.dto.ApiResult;
 import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.component.QuestionMapper;
@@ -17,7 +16,6 @@ import net.mureng.mureng.reply.component.ReplyMapper;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.service.ReplyService;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,7 +35,7 @@ public class QuestionController {
 
     @ApiOperation(value = "질문 목록 정렬 페이징 조회", notes = "질문 목록을 정렬 페이징해서 가져옵니다.")
     @GetMapping
-    public ResponseEntity<ApiResult<List<QuestionDto>>> getQuestionList(ApiPageRequest pageRequest,
+    public ResponseEntity<ApiResult<List<QuestionDto.ReadOnly>>> getQuestionList(ApiPageRequest pageRequest,
             @ApiParam(value = "페이지 정렬 방식(popular, newest)" ,required = false)
             @RequestParam(required = false, defaultValue = "popular") String sort) {
 
@@ -45,36 +43,36 @@ public class QuestionController {
 
         return ResponseEntity.ok(ApiResult.ok(
                 questionList.stream()
-                .map(questionMapper::map)
+                .map(questionMapper::toDto)
                 .collect(Collectors.toList())
         ));
     }
 
     @ApiOperation(value = "질문 조회", notes = "해당 질문을 가져옵니다.")
     @GetMapping("/{questionId}")
-    public ResponseEntity<ApiResult<QuestionDto>> getQuestionById(
+    public ResponseEntity<ApiResult<QuestionDto.ReadOnly>> getQuestionById(
             @ApiParam(value = "질문 id" ,required = true) @PathVariable @NotNull Long questionId){
 
         return ResponseEntity.ok(ApiResult.ok(
-                questionMapper.map(questionService.getQuestionById(questionId))
+                questionMapper.toDto(questionService.getQuestionById(questionId))
         ));
     }
 
     @ApiOperation(value = "내가 만든 질문 목록 조회", notes = "해당 사용자가 만든 질문 목록을 가져옵니다.")
     @GetMapping("/me")
-    public ResponseEntity<ApiResult<List<QuestionDto>>> getQuestionWrittenByMe(@CurrentUser Member member){
+    public ResponseEntity<ApiResult<List<QuestionDto.ReadOnly>>> getQuestionWrittenByMe(@CurrentUser Member member){
         List<Question> questionList =  questionService.getQuestionWrittenByMember(member.getMemberId());
 
         return ResponseEntity.ok(ApiResult.ok(
                 questionList.stream()
-                .map(questionMapper::map)
+                .map(questionMapper::toDto)
                 .collect(Collectors.toList())
         ));
     }
 
     @ApiOperation(value = "질문 관련 답변 가져오기", notes = "질문 관련 답변 가져오기")
     @GetMapping("/{questionId}/replies")
-    public ResponseEntity<ApiResult<List<ReplyDto>>> getQuestionReplies(
+    public ResponseEntity<ApiResult<List<ReplyDto.ReadOnly>>> getQuestionReplies(
             @ApiParam(value = "질문 id" ,required = true) @PathVariable Long questionId, ApiPageRequest pageRequest,
             @ApiParam(value = "페이지 정렬 방식(popular, newest)")
             @RequestParam(required = false, defaultValue = "popular") String sort) {
@@ -83,7 +81,7 @@ public class QuestionController {
                 ApiResult.ok(
                         replyService.findRepliesByQuestionId(questionId, pageRequest.convert(), sort)
                         .stream()
-                        .map(replyMapper::map)
+                        .map(replyMapper::toDto)
                         .collect(Collectors.toList())
                 )
         );

--- a/src/main/java/net/mureng/mureng/question/web/TodayQuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/TodayQuestionController.java
@@ -26,8 +26,8 @@ public class TodayQuestionController {
 
     @ApiOperation(value = "오늘의 질문 가져오기", notes = "현재 로그인한 사용자의 오늘의 질문을 가져옵니다.")
     @GetMapping("")
-    public ResponseEntity<ApiResult<QuestionDto>> get(@CurrentUser Member member) {
-        return ResponseEntity.ok(ApiResult.ok(questionMapper.map(
+    public ResponseEntity<ApiResult<QuestionDto.ReadOnly>> get(@CurrentUser Member member) {
+        return ResponseEntity.ok(ApiResult.ok(questionMapper.toDto(
                 todayQuestionService.getTodayQuestionByMemberId(member.getMemberId())
         )));
     }
@@ -35,7 +35,7 @@ public class TodayQuestionController {
     @ApiOperation(value = "오늘의 질문 새로고침해서 가져오기", notes = "오늘의 질문을 새로고침 해서 가져옵니다.")
     @GetMapping("/refresh")
     public ResponseEntity<ApiResult<QuestionDto>> getRefresh(@CurrentUser Member member) {
-        return ResponseEntity.ok(ApiResult.ok(questionMapper.map(
+        return ResponseEntity.ok(ApiResult.ok(questionMapper.toDto(
                 todayQuestionSelectionService.reselectTodayQuestion(member)
         )));
     }

--- a/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
+++ b/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
@@ -1,58 +1,32 @@
 package net.mureng.mureng.reply.component;
 
-import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.component.EntityMapper;
 import net.mureng.mureng.member.component.MemberMapper;
-import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.component.QuestionMapper;
+import net.mureng.mureng.question.component.WordHintMapper;
+import net.mureng.mureng.question.dto.QuestionDto;
 import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.entity.Reply;
-import net.mureng.mureng.reply.entity.ReplyLikes;
-import org.modelmapper.Converter;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-import java.util.List;
-import java.util.Set;
-
-@Component
-@RequiredArgsConstructor
-public class ReplyMapper extends EntityMapper {
-    private final QuestionMapper questionMapper;
-    private final MemberMapper memberMapper;
+@Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class })
+public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
+    @Override
+    @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
+    @Mapping(target = "questionId", expression = "java(reply.getQuestion().getQuestionId())")
+    ReplyDto.ReadOnly toDto(Reply reply);
 
     @Override
-    protected void initEntityToDtoMapping() {
-        final Converter<Set<ReplyLikes>, Integer> repliesCountConverter = context -> {
-            if (context == null)
-                return null;
-
-            return context.getSource().size();
-        };
-
-        modelMapper.createTypeMap(Reply.class, ReplyDto.class)
-                .addMappings(mapper -> mapper.skip(ReplyDto::setQuestionId))
-                .addMappings(mapper -> mapper.using(context -> questionMapper.map((Question) context.getSource()))
-                        .map(Reply::getQuestion, ReplyDto::setQuestion))
-                .addMappings(mapper -> mapper.using(repliesCountConverter)
-                        .map(Reply::getReplyLikes, ReplyDto::setReplyLikeCount))
-                .addMappings(mapper -> mapper.using(context -> memberMapper.map((Member) context.getSource()))
-                        .map(Reply::getMember, ReplyDto::setAuthor));
-    }
-
-    @Override
-    protected void initDtoToEntityMapping() {
-        modelMapper.createTypeMap(ReplyDto.class, Reply.class)
-                .addMappings(mapper -> mapper.skip(Reply::setMember))
-                .addMappings(mapper -> mapper.skip(Reply::setQuestion))
-                .addMappings(mapper -> mapper.skip(Reply::setVisible))
-                .addMappings(mapper -> mapper.skip(Reply::setDeleted))
-                .addMappings(mapper -> mapper.skip(Reply::setModDate))
-                .addMappings(mapper -> mapper.skip(Reply::setRegDate))
-                .addMappings(mapper -> mapper.skip(Reply::setReplyLikes));
-    }
-
-    public Reply map(ReplyDto replyDto) { return modelMapper.map(replyDto, Reply.class); }
-
-    public ReplyDto map(Reply reply) { return modelMapper.map(reply, ReplyDto.class); }
+    @Mapping(target = "replyId", ignore = true)
+    @Mapping(target = "author", ignore = true)
+    @Mapping(target = "question", ignore = true)
+    @Mapping(target = "visible", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "modDate", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    @Mapping(target = "replyLikes", ignore = true)
+    Reply toEntity(ReplyDto replyDto);
 }

--- a/src/main/java/net/mureng/mureng/reply/dto/ReplyDto.java
+++ b/src/main/java/net/mureng/mureng/reply/dto/ReplyDto.java
@@ -4,36 +4,46 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import net.mureng.mureng.member.dto.MemberDto;
 import net.mureng.mureng.question.dto.QuestionDto;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
-@Builder
+@SuperBuilder
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel(value="답변 모델", description="질문에 대한 답변을 나타내는 모델")
 public class ReplyDto {
-    @ApiModelProperty(value = "답변 기본키")
-    private Long replyId;
-
-    @ApiModelProperty(value = "질문 기본키")
+    @Min(1)
+    @ApiModelProperty(value = "답변하려는 질문의 기본키", required = true)
     private Long questionId;
 
     @NotEmpty
-    @ApiModelProperty(value = "답변 내용")
+    @ApiModelProperty(value = "답변 내용", required = true)
     private String content;
 
-    @ApiModelProperty(value = "이미지")
+    @ApiModelProperty(value = "이미지 경로", required = true)
     private String image;
 
-    @ApiModelProperty(value = "좋아요 갯수")
-    private int replyLikeCount;
+    @SuperBuilder
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value="답변 읽기 모델", description="질문에 대한 답변을 나타내는 읽기 전용 모델")
+    public static class ReadOnly extends ReplyDto {
+        @ApiModelProperty(value = "답변 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private Long replyId;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private QuestionDto question;
+        @ApiModelProperty(value = "좋아요 갯수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private int replyLikeCount;
 
-    @ApiModelProperty(hidden = true, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private MemberDto author;
+        @ApiModelProperty(value = "질문 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private QuestionDto.ReadOnly question;
+
+        @ApiModelProperty(value = "작성자 회원 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        private MemberDto.ReadOnly author;
+    }
 }

--- a/src/main/java/net/mureng/mureng/reply/entity/Reply.java
+++ b/src/main/java/net/mureng/mureng/reply/entity/Reply.java
@@ -24,7 +24,7 @@ public class Reply {
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member author;
 
     @ManyToOne
     @JoinColumn(name = "question_id")
@@ -63,7 +63,7 @@ public class Reply {
     }
 
     public boolean isWriter(Member member){
-        return this.member.getMemberId() == member.getMemberId();
+        return this.author.getMemberId() == member.getMemberId();
     }
 
 }

--- a/src/main/java/net/mureng/mureng/reply/repository/ReplyRepository.java
+++ b/src/main/java/net/mureng/mureng/reply/repository/ReplyRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
-    List<Reply> findAllByMemberMemberId(Long memberId);
+    List<Reply> findAllByAuthorMemberId(Long memberId);
     List<Reply> findAllByQuestionQuestionId(Long questionId);
     Page<Reply> findAllByQuestionQuestionId(Long questionId, Pageable pageable);
 
@@ -23,7 +23,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     @Query("Select r from Reply r order by r.replyLikes.size desc")
     Page<Reply> findAllByOrderByReplyLikesSize(Pageable pageable);
 
-    boolean existsByRegDateBetweenAndMemberMemberId(LocalDateTime startDateTime, LocalDateTime endDateTime, Long memberId);
-    Optional<Reply> findByMemberMemberIdAndQuestionQuestionId(Long memberId, Long questionId);
+    boolean existsByRegDateBetweenAndAuthorMemberId(LocalDateTime startDateTime, LocalDateTime endDateTime, Long memberId);
+    Optional<Reply> findByAuthorMemberIdAndQuestionQuestionId(Long memberId, Long questionId);
 
 }

--- a/src/main/java/net/mureng/mureng/reply/service/ReplyService.java
+++ b/src/main/java/net/mureng/mureng/reply/service/ReplyService.java
@@ -40,7 +40,7 @@ public class ReplyService {
 
     @Transactional
     public Reply create(Reply newReply) {
-        Long memberId = newReply.getMember().getMemberId();
+        Long memberId = newReply.getAuthor().getMemberId();
         Long questionId = newReply.getQuestion().getQuestionId();
 
         if (isAlreadyReplied(memberId))
@@ -52,7 +52,7 @@ public class ReplyService {
         if (questionService.isAlreadyReplied(questionId, memberId))
             throw new BadRequestException("이미 답변한 질문입니다.");
 
-        newReply.setMember(newReply.getMember());
+        newReply.setAuthor(newReply.getAuthor());
         newReply.setQuestion(questionService.getQuestionById(questionId));
 
         return replyRepository.saveAndFlush(newReply);
@@ -63,7 +63,7 @@ public class ReplyService {
         LocalDateTime startDateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0, 0)); // 오늘 00:00:00
         LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59, 59)); //오늘 23:59:59
 
-        return replyRepository.existsByRegDateBetweenAndMemberMemberId(startDateTime, endDatetime, memberId);
+        return replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime, endDatetime, memberId);
     }
 
     @Transactional
@@ -73,7 +73,7 @@ public class ReplyService {
         Reply oldReply = replyRepository.findById(replyId)
                 .orElseThrow(() -> new BadRequestException("존재하지 않는 질문에 대한 요청입니다."));
 
-        if (!oldReply.isWriter(newReply.getMember()))
+        if (!oldReply.isWriter(newReply.getAuthor()))
             throw new AccessNotAllowedException("접근 권한이 없습니다.");
 
         oldReply.modifyReply(newReply);

--- a/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
+++ b/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
@@ -3,8 +3,6 @@ package net.mureng.mureng.reply.web;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiPageRequest;
@@ -15,10 +13,8 @@ import net.mureng.mureng.reply.component.ReplyMapper;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.reply.service.ReplyService;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -41,36 +37,36 @@ public class ReplyController {
 
         return ResponseEntity.ok(ApiResult.ok(
                 replyService.findReplies(pageRequest.convert(), sort).stream()
-                .map(replyMapper::map)
+                .map(replyMapper::toDto)
                 .collect(Collectors.toList())
         ));
     }
 
     @ApiOperation(value = "답변 작성하기", notes = "현재 질문에 대한 답변을 작성합니다.")
     @PostMapping
-    public ResponseEntity<ApiResult<ReplyDto>> create(@CurrentUser Member member,
+    public ResponseEntity<ApiResult<ReplyDto.ReadOnly>> create(@CurrentUser Member member,
                                             @RequestBody @Valid ReplyDto replyDto){
 
-        Reply newReply = replyMapper.map(replyDto);
-        newReply.setMember(member);
+        Reply newReply = replyMapper.toEntity(replyDto);
+        newReply.setAuthor(member);
         newReply.setQuestion(Question.builder().questionId(replyDto.getQuestionId()).build());
 
-        return ResponseEntity.ok(ApiResult.ok(replyMapper.map(
+        return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.create(newReply)
         )));
     }
 
     @ApiOperation(value = "답변 수정하기", notes = "답변을 수정합니다.")
     @PutMapping("/{replyId}")
-    public ResponseEntity<ApiResult<ReplyDto>> update(@CurrentUser Member member,
+    public ResponseEntity<ApiResult<ReplyDto.ReadOnly>> update(@CurrentUser Member member,
                                             @RequestBody @Valid ReplyDto replyDto,
                                             @PathVariable @NotNull Long replyId){
 
-        Reply newReply = replyMapper.map(replyDto);
-        newReply.setMember(member);
+        Reply newReply = replyMapper.toEntity(replyDto);
+        newReply.setAuthor(member);
         newReply.setReplyId(replyId);
 
-        return ResponseEntity.ok(ApiResult.ok(replyMapper.map(
+        return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.update(newReply)
         )));
     }

--- a/src/test/java/net/mureng/mureng/common/EntityCreator.java
+++ b/src/test/java/net/mureng/mureng/common/EntityCreator.java
@@ -39,7 +39,7 @@ public class EntityCreator {
     public static Reply createReplyEntity(){
         return Reply.builder()
                 .replyId(REPLY_ID)
-                .member(createMemberEntity())
+                .author(createMemberEntity())
                 .question(createQuestionEntity())
                 .content("Test Reply")
                 .image("image-path")

--- a/src/test/java/net/mureng/mureng/member/component/MemberMapperTest.java
+++ b/src/test/java/net/mureng/mureng/member/component/MemberMapperTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,7 +36,7 @@ class MemberMapperTest {
                                                 .build())
                                         .build();
 
-    private final MemberDto memberDto = MemberDto.builder()
+    private final MemberDto.ReadOnly memberDto = MemberDto.ReadOnly.builder()
                                         .memberId(1L)
                                         .identifier("123")
                                         .email("test@gmail.com")
@@ -50,7 +49,7 @@ class MemberMapperTest {
 
     @Test
     void 엔티티에서_DTO변환_테스트() {
-        MemberDto mappedDto = memberMapper.map(member);
+        MemberDto.ReadOnly mappedDto = memberMapper.toDto(member);
         assertEquals(mappedDto.getMemberId(), memberDto.getMemberId());
         assertEquals(mappedDto.getIdentifier(), memberDto.getIdentifier());
         assertEquals(mappedDto.getImage(), memberDto.getImage());
@@ -64,7 +63,7 @@ class MemberMapperTest {
 
     @Test
     void DTO에서_엔티티변환_테스트() {
-        Member mappedMember = memberMapper.map(memberDto);
+        Member mappedMember = memberMapper.toEntity(memberDto);
 //        assertEquals(mappedMember.getMemberId(), member.getMemberId());
         assertEquals(mappedMember.getIdentifier(), member.getIdentifier());
         assertEquals(mappedMember.getEmail(), member.getEmail());

--- a/src/test/java/net/mureng/mureng/question/component/QuestionMapperTest.java
+++ b/src/test/java/net/mureng/mureng/question/component/QuestionMapperTest.java
@@ -31,7 +31,7 @@ class QuestionMapperTest {
             .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
             .build();
 
-    private final WordHintDto wordHintDto = WordHintDto.builder()
+    private final WordHintDto.ReadOnly wordHintDto = WordHintDto.ReadOnly.builder()
             .hintId(1L)
             .word("apple")
             .meaning("사과")
@@ -50,18 +50,18 @@ class QuestionMapperTest {
             .replies(replies)
             .build();
 
-    private final QuestionDto questionDto = QuestionDto.builder()
+    private final QuestionDto.ReadOnly questionDto = QuestionDto.ReadOnly.builder()
             .questionId(1L)
             .category("카테고리")
             .content("This is english content.")
             .koContent("이것은 한글 내용입니다.")
             .wordHints(Set.of(wordHintDto))
-            .repliesCount(2L)
+            .repliesCount(2)
             .build();
 
     @Test
     public void 엔티티에서_DTO변환_테스트() {
-        QuestionDto mappedDto = questionMapper.map(question);
+        QuestionDto.ReadOnly mappedDto = questionMapper.toDto(question);
         assertEquals(questionDto.getQuestionId(), mappedDto.getQuestionId());
         assertEquals(questionDto.getCategory(), mappedDto.getCategory());
         assertEquals(questionDto.getContent(), mappedDto.getContent());
@@ -72,11 +72,11 @@ class QuestionMapperTest {
 
     @Test
     public void DTO에서_엔티티변환_테스트() {
-        Question mappedEntity = questionMapper.map(questionDto);
-        assertEquals(question.getQuestionId(), mappedEntity.getQuestionId());
+        Question mappedEntity = questionMapper.toEntity(questionDto);
+//        assertEquals(question.getQuestionId(), mappedEntity.getQuestionId());
         assertEquals(question.getCategory(), mappedEntity.getCategory());
         assertEquals(question.getContent(), mappedEntity.getContent());
         assertEquals(question.getKoContent(), mappedEntity.getKoContent());
-        assertEquals(question.getWordHints().size(), mappedEntity.getWordHints().size());
+//        assertEquals(question.getWordHints().size(), mappedEntity.getWordHints().size());
     }
 }

--- a/src/test/java/net/mureng/mureng/question/component/WordHintMapperTest.java
+++ b/src/test/java/net/mureng/mureng/question/component/WordHintMapperTest.java
@@ -24,7 +24,7 @@ class WordHintMapperTest {
             .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
             .build();
 
-    private final WordHintDto wordHintDto = WordHintDto.builder()
+    private final WordHintDto.ReadOnly wordHintDto = WordHintDto.ReadOnly.builder()
             .hintId(1L)
             .word("apple")
             .meaning("사과")
@@ -32,7 +32,7 @@ class WordHintMapperTest {
 
     @Test
     public void 엔티티에서_DTO변환_테스트() {
-        WordHintDto mappedDto = wordHintMapper.map(wordHint);
+        WordHintDto.ReadOnly mappedDto = wordHintMapper.toDto(wordHint);
         assertEquals(wordHintDto.getHintId(), mappedDto.getHintId());
         assertEquals(wordHintDto.getWord(), mappedDto.getWord());
         assertEquals(wordHintDto.getMeaning(), mappedDto.getMeaning());
@@ -40,8 +40,7 @@ class WordHintMapperTest {
 
     @Test
     public void DTO에서_엔티티변환_테스트() {
-        WordHint mappedEntity = wordHintMapper.map(wordHintDto);
-        assertEquals(wordHint.getHintId(), mappedEntity.getHintId());
+        WordHint mappedEntity = wordHintMapper.toEntity(wordHintDto);
         assertEquals(wordHint.getWord(), mappedEntity.getWord());
         assertEquals(wordHint.getMeaning(), mappedEntity.getMeaning());
     }

--- a/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
+++ b/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
@@ -1,0 +1,7 @@
+package net.mureng.mureng.reply.component;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplyMapperTest {
+
+}

--- a/src/test/java/net/mureng/mureng/reply/repository/ReplyRepositoryTest.java
+++ b/src/test/java/net/mureng/mureng/reply/repository/ReplyRepositoryTest.java
@@ -34,15 +34,15 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 멤버_답변_목록_조회(){
-        List<Reply> replyList = replyRepository.findAllByMemberMemberId(MEMBER_ID);
+        List<Reply> replyList = replyRepository.findAllByAuthorMemberId(MEMBER_ID);
 
         assertEquals(2, replyList.size());
 
-        assertEquals(MEMBER_ID, replyList.get(0).getMember().getMemberId());
+        assertEquals(MEMBER_ID, replyList.get(0).getAuthor().getMemberId());
         assertEquals("yellow", replyList.get(0).getContent());
         assertEquals("yellow image", replyList.get(0).getImage());
 
-        assertEquals(MEMBER_ID, replyList.get(1).getMember().getMemberId());
+        assertEquals(MEMBER_ID, replyList.get(1).getAuthor().getMemberId());
         assertEquals("so cute", replyList.get(1).getContent());
         assertEquals("cat image", replyList.get(1).getImage());
     }
@@ -84,8 +84,8 @@ public class ReplyRepositoryTest {
         LocalDateTime startDateTime2 = LocalDateTime.of(date2, LocalTime.of(0,0,0));
         LocalDateTime endDateTime2 = LocalDateTime.of(date2, LocalTime.of(23,59,59));
 
-        boolean isExist = replyRepository.existsByRegDateBetweenAndMemberMemberId(startDateTime, endDateTime, MEMBER_ID);
-        boolean isExist2 = replyRepository.existsByRegDateBetweenAndMemberMemberId(startDateTime2, endDateTime2, MEMBER_ID);
+        boolean isExist = replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime, endDateTime, MEMBER_ID);
+        boolean isExist2 = replyRepository.existsByRegDateBetweenAndAuthorMemberId(startDateTime2, endDateTime2, MEMBER_ID);
 
         assertTrue(isExist);
         assertFalse(isExist2);
@@ -93,10 +93,10 @@ public class ReplyRepositoryTest {
 
     @Test
     public void 멤버와_질문으로_답변_찾기_테스트() {
-        Reply oldReply = replyRepository.findByMemberMemberIdAndQuestionQuestionId(MEMBER_ID, QUESTION_ID).orElseThrow();
+        Reply oldReply = replyRepository.findByAuthorMemberIdAndQuestionQuestionId(MEMBER_ID, QUESTION_ID).orElseThrow();
 
         assertEquals(REPLY_ID, oldReply.getReplyId());
-        assertEquals(MEMBER_ID, oldReply.getMember().getMemberId());
+        assertEquals(MEMBER_ID, oldReply.getAuthor().getMemberId());
         assertEquals(QUESTION_ID, oldReply.getQuestion().getQuestionId());
         assertEquals("yellow", oldReply.getContent());
         assertEquals("yellow image", oldReply.getImage());

--- a/src/test/java/net/mureng/mureng/reply/service/ReplyServiceTest.java
+++ b/src/test/java/net/mureng/mureng/reply/service/ReplyServiceTest.java
@@ -49,7 +49,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndMemberMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(true);
             given(questionService.isAlreadyReplied(eq(QUESTION_ID), eq(notRepliedMemberId))).willReturn(false);
             given(questionService.getQuestionById(eq(QUESTION_ID))).willReturn(newReply.getQuestion());
@@ -72,7 +72,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndMemberMemberId(any(), any(), eq(repliedMemberId))).willReturn(true);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(repliedMemberId))).willReturn(true);
 
             // when
             BadRequestException exception =  assertThrows(BadRequestException.class, () -> replyService.create(newReply));
@@ -89,7 +89,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndMemberMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(notRepliedMemberId))).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(false);
 
             // when
@@ -107,7 +107,7 @@ public class ReplyServiceTest {
             Reply newReply = EntityCreator.createReplyEntity();
 
             // mocking
-            given(replyRepository.existsByRegDateBetweenAndMemberMemberId(any(), any(), eq(MEMBER_ID))).willReturn(false);
+            given(replyRepository.existsByRegDateBetweenAndAuthorMemberId(any(), any(), eq(MEMBER_ID))).willReturn(false);
             given(questionService.existsById(eq(QUESTION_ID))).willReturn(true);
             given(questionService.isAlreadyReplied(eq(QUESTION_ID), eq(repliedMemberId))).willReturn(true);
 
@@ -128,7 +128,7 @@ public class ReplyServiceTest {
 
             Reply newReply = Reply.builder()
                             .replyId(REPLY_ID)
-                            .member(EntityCreator.createMemberEntity())
+                            .author(EntityCreator.createMemberEntity())
                             .content("New Test Content")
                             .image("New Image Path")
                             .modDate(now)
@@ -156,7 +156,7 @@ public class ReplyServiceTest {
 
             Reply newReply = Reply.builder()
                             .replyId(REPLY_ID)
-                            .member(EntityCreator.createMemberEntity())
+                            .author(EntityCreator.createMemberEntity())
                             .content("New Test Content")
                             .image("New Image Path")
                             .modDate(now)

--- a/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
+++ b/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
@@ -53,7 +53,7 @@ public class ReplyControllerTest extends AbstractControllerTest {
 
     private final Reply newReply = Reply.builder()
             .replyId(1L)
-            .member(Member.builder().build())
+            .author(Member.builder().build())
             .question(question)
             .content("Test Reply")
             .image("image-path")


### PR DESCRIPTION
- 기존 modelmapper 로 매핑하던 로직을 mapstruct 으로 변경함, 실제로 사용해보니, 더욱 직관적이고 스마트해서 좋음!!
- 쓰기 DTO와 읽기 DTO 분리, 정확히는 기존 DTO 안에 읽기전용 필드를 모아 내부 정적 클래스로 선언 (ReadOnly)

알려진 이슈: 원리가 동적으로 코드를 생성하도록 되어있는데, 매핑을 잘 해줬는데도 간헐적으로 컴파일이 실패한다(매핑 필드를 못찾는다고 나옴). 이 경우 다시 컴파일 하면 정상 작동한다. 클린 후 빌드하면 이 이슈가 발생하지 않는다.