### PR TITLE
[보완] 페이징 관련 엔드포인트 응답에 페이지 정보 추가

### DIFF
--- a/src/main/java/net/mureng/mureng/core/dto/ApiPageResult.java
+++ b/src/main/java/net/mureng/mureng/core/dto/ApiPageResult.java
@@ -9,30 +9,30 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 @Getter
-@ApiModel(value="페이징이 적용된 API 응답 모델")
-public class ApiPageResult extends ApiResult<List<?>> {
+@ApiModel(value="페이징 API 응답 모델")
+public class ApiPageResult<T> extends ApiResult<List<T>> {
 
-    @ApiModelProperty(value = "페이지 번호")
+    @ApiModelProperty(value = "페이지 번호", position = 2)
     private final int currentPage;
 
-    @ApiModelProperty(value = "총합 페이지")
+    @ApiModelProperty(value = "총합 페이지", position = 3)
     private final int totalPage;
 
-    @ApiModelProperty(value = "페이지 크기")
+    @ApiModelProperty(value = "페이지 크기", position = 4)
     private final int pageSize;
 
-    public ApiPageResult(Page<?> data, String message, ApiPageRequest pageRequest) {
+    public ApiPageResult(Page<T> data, String message) {
         super(message, data.getContent());
-        this.currentPage = pageRequest.getPage();
-        this.pageSize = pageRequest.getSize();
+        this.currentPage = data.getPageable().getPageNumber();
+        this.pageSize = data.getPageable().getPageSize();
         this.totalPage = data.getTotalPages();
     }
 
-    public static ApiPageResult ok(Page<?> data, ApiPageRequest pageRequest) {
-        return ok(data, "ok", pageRequest);
+    public static <T> ApiPageResult<T> ok(Page<T> data) {
+        return ok(data, "ok");
     }
 
-    public static ApiPageResult ok(Page<?> data, String message, ApiPageRequest pageRequest) {
-        return new ApiPageResult(data, message, pageRequest);
+    public static <T> ApiPageResult<T> ok(Page<T> data, String message) {
+        return new ApiPageResult<>(data, message);
     }
 }

--- a/src/main/java/net/mureng/mureng/core/dto/ApiResult.java
+++ b/src/main/java/net/mureng/mureng/core/dto/ApiResult.java
@@ -9,13 +9,13 @@ import lombok.Getter;
 @ApiModel(value="API 응답 공통 모델")
 public class ApiResult<T> {
 
-    @ApiModelProperty(value = "결과 메세지")
+    @ApiModelProperty(value = "결과 메세지", position = 0)
     protected final String message;
 
-    @ApiModelProperty(value = "응답 데이터, 실패시 null")
+    @ApiModelProperty(value = "응답 데이터, 실패시 null", position = 1)
     protected final T data;
 
-    @ApiModelProperty(value = "요청 서버 시간")
+    @ApiModelProperty(value = "요청 서버 시간", position = 5)
     protected final long timestamp;
 
     public ApiResult(String message, T data) {

--- a/src/main/java/net/mureng/mureng/member/dto/MemberDto.java
+++ b/src/main/java/net/mureng/mureng/member/dto/MemberDto.java
@@ -17,18 +17,18 @@ import javax.validation.constraints.NotEmpty;
 @ApiModel(value="회원 모델", description="회원을 나타내는 모델")
 public class MemberDto {
     @NotEmpty
-    @ApiModelProperty(value = "회원 식별값", required = true)
+    @ApiModelProperty(value = "회원 식별값", required = true, position = 1)
     private String identifier;
 
     @Email
-    @ApiModelProperty(value = "이메일 주소", required = true)
+    @ApiModelProperty(value = "이메일 주소", required = true, position = 2)
     private String email;
 
     @NotEmpty
-    @ApiModelProperty(value = "닉네임", required = true)
+    @ApiModelProperty(value = "닉네임", required = true, position = 3)
     private String nickname;
 
-    @ApiModelProperty(value = "프로필 이미지 경로")
+    @ApiModelProperty(value = "프로필 이미지 경로", position = 4)
     private String image;
 
     @SuperBuilder
@@ -37,19 +37,19 @@ public class MemberDto {
     @AllArgsConstructor
     @ApiModel(value="회원 읽기 모델", description="읽기 전용 회원 모델")
     public static class ReadOnly extends MemberDto {
-        @ApiModelProperty(value = "회원 고유 아이디", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "회원 고유 아이디", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 0)
         private Long memberId;
 
-        @ApiModelProperty(value = "머렝 개수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "머렝 개수", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 5)
         private int murengCount;
 
-        @ApiModelProperty(value = "출석 일수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "출석 일수", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 6)
         private int attendanceCount;
 
-        @ApiModelProperty(value = "마지막 출석 날짜", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "마지막 출석 날짜", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 7)
         private String lastAttendanceDate;
 
-        @ApiModelProperty(value = "푸쉬 알림 여부", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "푸쉬 알림 여부", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 8)
         private boolean isPushActive;
     }
 }

--- a/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
+++ b/src/main/java/net/mureng/mureng/question/dto/QuestionDto.java
@@ -14,14 +14,14 @@ import java.util.Set;
 @AllArgsConstructor
 @ApiModel(value="질문 모델", description="질문을 나타내는 모델")
 public class QuestionDto {
-    @ApiModelProperty(value = "카테고리")
+    @ApiModelProperty(value = "카테고리", position = 1)
     private String category;
 
     @NotEmpty
-    @ApiModelProperty(value = "영문 내용", required = true)
+    @ApiModelProperty(value = "영문 내용", required = true, position = 2)
     private String content;
 
-    @ApiModelProperty(value = "한글 내용")
+    @ApiModelProperty(value = "한글 내용", position = 3)
     private String koContent;
 
     @SuperBuilder
@@ -30,13 +30,13 @@ public class QuestionDto {
     @AllArgsConstructor
     @ApiModel(value="질문 읽기 모델", description="질문을 나타내는 읽기 모델")
     public static class ReadOnly extends QuestionDto {
-        @ApiModelProperty(value = "질문 기본 키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "질문 기본 키", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 0)
         private Long questionId;
 
-        @ApiModelProperty(value = "연관된 단어 힌트들", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "연관된 단어 힌트들", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 4)
         private Set<WordHintDto.ReadOnly> wordHints;
 
-        @ApiModelProperty(value = "작성된 답변 수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "작성된 답변 수", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 5)
         private int repliesCount;
     }
 }

--- a/src/main/java/net/mureng/mureng/question/dto/WordHintDto.java
+++ b/src/main/java/net/mureng/mureng/question/dto/WordHintDto.java
@@ -17,10 +17,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @ApiModel(value="단어 힌트 모델", description="단어 힌트를 나타내는 모델")
 public class WordHintDto {
-    @ApiModelProperty(value = "단어")
+    @ApiModelProperty(value = "단어", position = 1)
     private String word;
 
-    @ApiModelProperty(value = "뜻")
+    @ApiModelProperty(value = "뜻", position = 2)
     private String meaning;
 
     @SuperBuilder
@@ -29,7 +29,7 @@ public class WordHintDto {
     @AllArgsConstructor
     @ApiModel(value="단어 힌트 읽기 모델", description="단어 힌트를 나타내는 읽기 모델")
     public static class ReadOnly extends WordHintDto {
-        @ApiModelProperty(value = "단어 힌트 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "단어 힌트 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 0)
         private Long hintId;
     }
 }

--- a/src/main/java/net/mureng/mureng/question/web/QuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/QuestionController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiPageRequest;
+import net.mureng.mureng.core.dto.ApiPageResult;
 import net.mureng.mureng.core.dto.ApiResult;
 import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.component.QuestionMapper;
@@ -14,8 +15,10 @@ import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.question.service.QuestionService;
 import net.mureng.mureng.reply.component.ReplyMapper;
 import net.mureng.mureng.reply.dto.ReplyDto;
+import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.reply.service.ReplyService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,16 +38,13 @@ public class QuestionController {
 
     @ApiOperation(value = "질문 목록 정렬 페이징 조회", notes = "질문 목록을 정렬 페이징해서 가져옵니다.")
     @GetMapping
-    public ResponseEntity<ApiResult<List<QuestionDto.ReadOnly>>> getQuestionList(ApiPageRequest pageRequest,
+    public ResponseEntity<ApiPageResult<QuestionDto.ReadOnly>> getQuestionList(ApiPageRequest pageRequest,
             @ApiParam(value = "페이지 정렬 방식(popular, newest)" ,required = false)
             @RequestParam(required = false, defaultValue = "popular") String sort) {
 
-        Page<Question> questionList = questionService.getQuestionList(pageRequest.convert(), sort);
-
-        return ResponseEntity.ok(ApiResult.ok(
-                questionList.stream()
-                .map(questionMapper::toDto)
-                .collect(Collectors.toList())
+        return ResponseEntity.ok(ApiPageResult.ok(
+                questionService.getQuestionList(pageRequest.convert(), sort)
+                        .map(questionMapper::toDto)
         ));
     }
 
@@ -72,18 +72,15 @@ public class QuestionController {
 
     @ApiOperation(value = "질문 관련 답변 가져오기", notes = "질문 관련 답변 가져오기")
     @GetMapping("/{questionId}/replies")
-    public ResponseEntity<ApiResult<List<ReplyDto.ReadOnly>>> getQuestionReplies(
+    public ResponseEntity<ApiPageResult<ReplyDto.ReadOnly>> getQuestionReplies(
             @ApiParam(value = "질문 id" ,required = true) @PathVariable Long questionId, ApiPageRequest pageRequest,
             @ApiParam(value = "페이지 정렬 방식(popular, newest)")
             @RequestParam(required = false, defaultValue = "popular") String sort) {
 
         return ResponseEntity.ok(
-                ApiResult.ok(
+                ApiPageResult.ok(
                         replyService.findRepliesByQuestionId(questionId, pageRequest.convert(), sort)
-                        .stream()
-                        .map(replyMapper::toDto)
-                        .collect(Collectors.toList())
-                )
+                        .map(replyMapper::toDto))
         );
     }
 }

--- a/src/main/java/net/mureng/mureng/question/web/TodayQuestionController.java
+++ b/src/main/java/net/mureng/mureng/question/web/TodayQuestionController.java
@@ -34,7 +34,7 @@ public class TodayQuestionController {
 
     @ApiOperation(value = "오늘의 질문 새로고침해서 가져오기", notes = "오늘의 질문을 새로고침 해서 가져옵니다.")
     @GetMapping("/refresh")
-    public ResponseEntity<ApiResult<QuestionDto>> getRefresh(@CurrentUser Member member) {
+    public ResponseEntity<ApiResult<QuestionDto.ReadOnly>> getRefresh(@CurrentUser Member member) {
         return ResponseEntity.ok(ApiResult.ok(questionMapper.toDto(
                 todayQuestionSelectionService.reselectTodayQuestion(member)
         )));

--- a/src/main/java/net/mureng/mureng/reply/dto/ReplyDto.java
+++ b/src/main/java/net/mureng/mureng/reply/dto/ReplyDto.java
@@ -18,14 +18,14 @@ import javax.validation.constraints.NotEmpty;
 @ApiModel(value="답변 모델", description="질문에 대한 답변을 나타내는 모델")
 public class ReplyDto {
     @Min(1)
-    @ApiModelProperty(value = "답변하려는 질문의 기본키", required = true)
+    @ApiModelProperty(value = "답변하려는 질문의 기본키", required = true, position = 1)
     private Long questionId;
 
     @NotEmpty
-    @ApiModelProperty(value = "답변 내용", required = true)
+    @ApiModelProperty(value = "답변 내용", required = true, position = 2)
     private String content;
 
-    @ApiModelProperty(value = "이미지 경로", required = true)
+    @ApiModelProperty(value = "이미지 경로", required = true, position = 3)
     private String image;
 
     @SuperBuilder
@@ -34,16 +34,16 @@ public class ReplyDto {
     @AllArgsConstructor
     @ApiModel(value="답변 읽기 모델", description="질문에 대한 답변을 나타내는 읽기 전용 모델")
     public static class ReadOnly extends ReplyDto {
-        @ApiModelProperty(value = "답변 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "답변 기본키", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 0)
         private Long replyId;
 
-        @ApiModelProperty(value = "좋아요 갯수", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "좋아요 갯수", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 4)
         private int replyLikeCount;
 
-        @ApiModelProperty(value = "질문 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "질문 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 5)
         private QuestionDto.ReadOnly question;
 
-        @ApiModelProperty(value = "작성자 회원 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @ApiModelProperty(value = "작성자 회원 모델", accessMode = ApiModelProperty.AccessMode.READ_ONLY, position = 6)
         private MemberDto.ReadOnly author;
     }
 }

--- a/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
+++ b/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiPageRequest;
+import net.mureng.mureng.core.dto.ApiPageResult;
 import net.mureng.mureng.core.dto.ApiResult;
 import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.entity.Question;
@@ -31,14 +32,13 @@ public class ReplyController {
 
     @ApiOperation(value = "답변 목록 가져오기", notes = "전체 답변 목록을 페이징으로 가져옵니다.")
     @GetMapping
-    public ResponseEntity<ApiResult<List<ReplyDto>>> get(ApiPageRequest pageRequest,
-                                                         @ApiParam(value = "페이지 정렬 방식(popular, newest)")
+    public ResponseEntity<ApiPageResult<ReplyDto.ReadOnly>> get(ApiPageRequest pageRequest,
+                                                                      @ApiParam(value = "페이지 정렬 방식(popular, newest)")
                                                          @RequestParam(required = false, defaultValue = "popular") String sort){
 
-        return ResponseEntity.ok(ApiResult.ok(
-                replyService.findReplies(pageRequest.convert(), sort).stream()
+        return ResponseEntity.ok(ApiPageResult.ok(
+                replyService.findReplies(pageRequest.convert(), sort)
                 .map(replyMapper::toDto)
-                .collect(Collectors.toList())
         ));
     }
 

--- a/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
+++ b/src/test/java/net/mureng/mureng/question/web/QuestionControllerTest.java
@@ -56,7 +56,7 @@ public class QuestionControllerTest extends AbstractControllerTest {
             questionList.add(popularQuestion);
             questionList.add(EntityCreator.createQuestionEntity());
 
-            Page<Question> questionPage = new PageImpl<>(questionList);
+            Page<Question> questionPage = new PageImpl<>(questionList, PageRequest.of(page, size), 2);
 
             given(questionService.getQuestionList(eq(PageRequest.of(page, size)), eq("popular"))).willReturn(questionPage);
 
@@ -83,7 +83,7 @@ public class QuestionControllerTest extends AbstractControllerTest {
             questionList.add(popularQuestion);
             questionList.add(EntityCreator.createQuestionEntity());
 
-            Page<Question> questionPage = new PageImpl<>(questionList);
+            Page<Question> questionPage = new PageImpl<>(questionList, PageRequest.of(page, size), 2);
 
             given(questionService.getQuestionList(eq(PageRequest.of(page, size)), eq("newest"))).willReturn(questionPage);
 
@@ -154,7 +154,7 @@ public class QuestionControllerTest extends AbstractControllerTest {
         int size = 2;
 
         given(replyService.findRepliesByQuestionId(eq(1L), eq(PageRequest.of(page, size)), any()))
-                .willReturn(new PageImpl<>(replies));
+                .willReturn(new PageImpl<>(replies, PageRequest.of(page, size), 2));
 
         mockMvc.perform(
                 get("/api/questions/1/replies?page=0&size=2")

--- a/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
+++ b/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
@@ -83,7 +83,7 @@ public class ReplyControllerTest extends AbstractControllerTest {
         int size = 10;
 
         given(replyService.findReplies(eq(PageRequest.of(page, size)), any()))
-                .willReturn(new PageImpl<>(replies));
+                .willReturn(new PageImpl<>(replies, PageRequest.of(page, size), 2));
 
         mockMvc.perform(
                 get("/api/reply")


### PR DESCRIPTION
- 페이징이 포함된 요청에 현재 무슨 페이지인지, 총 페이지 갯수는 몇개인지 알 수 있도록 응답값 추가
- swagger 상에서 가독성 높이기 위해 DTO의 ApiModelProperty에 position 속성추가