### PR TITLE
[기능] 현재 로그인한 사용자 조회 엔드포인트 추가, 사용자 답변 컨트롤러 분리

### DIFF
--- a/src/main/java/net/mureng/mureng/member/web/MemberController.java
+++ b/src/main/java/net/mureng/mureng/member/web/MemberController.java
@@ -36,8 +36,6 @@ public class MemberController {
     private final MemberSignupService memberSignupService;
     private final MemberMapper memberMapper;
     private final OAuth2Service oAuth2Service;
-    private final ReplyService replyService;
-    private final ReplyMapper replyMapper;
 
     @ApiOperation(value = "신규 회원 가입", notes = "신규 회원가입입니다.")
     @PostMapping("/signup")
@@ -74,29 +72,11 @@ public class MemberController {
         ));
     }
 
-    @ApiOperation(value = "사용자가 답변한 질문 목록 조회", notes = "사용자가 답변한 질문 목록을 가져옵니다.")
-    @GetMapping("/replies")
-    public ResponseEntity<ApiResult<List<ReplyDto.ReadOnly>>> getQuestionMemberReplied(
-            @CurrentUser Member member){
-        return ResponseEntity.ok(
-                ApiResult.ok(
-                        replyService.findRepliesByMemberId(member.getMemberId()).stream()
-                        .map(replyMapper::toDto)
-                        .collect(Collectors.toList())
-                )
-        );
+    @ApiOperation(value = "로그인한 사용자 가져오기", notes = "현재 로그인한 사용자를 가져옵니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<MemberDto.ReadOnly>> me(@CurrentUser Member member) {
+        return ResponseEntity.ok(ApiResult.ok(memberMapper.toDto(member)));
     }
-
-    @ApiOperation(value = "오늘 사용자의 답변 유무 조회", notes = "사용자가 오늘 답변을 했는 지 확인합니다.")
-    @GetMapping("/check-replied-today")
-    public ResponseEntity<ApiResult<RepliedCheckDto>> isMemberRepliedToday(@CurrentUser Member member) {
-        return ResponseEntity.ok(
-                ApiResult.ok(
-                        new RepliedCheckDto(replyService.isAlreadyReplied(member.getMemberId()))
-                )
-        );
-    }
-
 
     @ApiIgnore
     @AllArgsConstructor
@@ -111,12 +91,5 @@ public class MemberController {
     public static class UserCheckDto {
         private final boolean exist;
         private final String email;
-    }
-
-    @ApiIgnore
-    @AllArgsConstructor
-    @Getter
-    public static class RepliedCheckDto {
-        private final boolean replied;
     }
 }

--- a/src/main/java/net/mureng/mureng/member/web/MemberReplyController.java
+++ b/src/main/java/net/mureng/mureng/member/web/MemberReplyController.java
@@ -1,0 +1,68 @@
+package net.mureng.mureng.member.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.mureng.mureng.core.annotation.CurrentUser;
+import net.mureng.mureng.core.dto.ApiResult;
+import net.mureng.mureng.core.jwt.dto.TokenDto;
+import net.mureng.mureng.core.oauth2.dto.OAuth2Profile;
+import net.mureng.mureng.core.oauth2.service.OAuth2Service;
+import net.mureng.mureng.member.component.MemberMapper;
+import net.mureng.mureng.member.dto.MemberDto;
+import net.mureng.mureng.member.entity.Member;
+import net.mureng.mureng.member.service.MemberService;
+import net.mureng.mureng.member.service.MemberSignupService;
+import net.mureng.mureng.reply.component.ReplyMapper;
+import net.mureng.mureng.reply.dto.ReplyDto;
+import net.mureng.mureng.reply.service.ReplyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api(value = "회원 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberReplyController {
+    private final ReplyService replyService;
+    private final ReplyMapper replyMapper;
+
+    @ApiOperation(value = "사용자가 답변한 질문 목록 조회", notes = "사용자가 답변한 질문 목록을 가져옵니다.")
+    @GetMapping("/replies")
+    public ResponseEntity<ApiResult<List<ReplyDto.ReadOnly>>> getQuestionMemberReplied(
+            @CurrentUser Member member){
+        return ResponseEntity.ok(
+                ApiResult.ok(
+                        replyService.findRepliesByMemberId(member.getMemberId()).stream()
+                        .map(replyMapper::toDto)
+                        .collect(Collectors.toList())
+                )
+        );
+    }
+
+    @ApiOperation(value = "오늘 사용자의 답변 유무 조회", notes = "사용자가 오늘 답변을 했는 지 확인합니다.")
+    @GetMapping("/check-replied-today")
+    public ResponseEntity<ApiResult<RepliedCheckDto>> isMemberRepliedToday(@CurrentUser Member member) {
+        return ResponseEntity.ok(
+                ApiResult.ok(
+                        new RepliedCheckDto(replyService.isAlreadyReplied(member.getMemberId()))
+                )
+        );
+    }
+
+
+    @ApiIgnore
+    @AllArgsConstructor
+    @Getter
+    public static class RepliedCheckDto {
+        private final boolean replied;
+    }
+}

--- a/src/test/java/net/mureng/mureng/member/web/MemberControllerTest.java
+++ b/src/test/java/net/mureng/mureng/member/web/MemberControllerTest.java
@@ -58,9 +58,6 @@ class MemberControllerTest extends AbstractControllerTest {
     @MockBean
     MemberSignupService memberSignupService;
 
-    @MockBean
-    ReplyService replyService;
-
     @Test
     public void 사용자_회원가입_테스트() throws Exception {
         given(memberSignupService.signup(any())).willReturn(newMember);
@@ -107,31 +104,14 @@ class MemberControllerTest extends AbstractControllerTest {
 
     @Test
     @WithMockMurengUser
-    public void 사용자_답변_목록_조회_테스트() throws Exception {
-        Member member = EntityCreator.createMemberEntity();
-        List<Reply> replies = Arrays.asList(EntityCreator.createReplyEntity(), EntityCreator.createReplyEntity());
-
-        given(replyService.findRepliesByMemberId(eq(1L))).willReturn(replies);
-
+    public void 로그인한_사용자_가져오기_테스트() throws Exception {
         mockMvc.perform(
-                get("/api/member/replies")
+                get("/api/member/me")
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andDo(print());
-    }
-
-    @Test
-    @WithMockMurengUser
-    public void 사용자_오늘_답변했는지_테스트() throws Exception {
-        given(replyService.isAlreadyReplied(eq(1L))).willReturn(true);
-
-        mockMvc.perform(
-                get("/api/member/check-replied-today")
-                .contentType(MediaType.APPLICATION_JSON)
-        ).andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replied").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("Test"))
                 .andDo(print());
     }
 }

--- a/src/test/java/net/mureng/mureng/member/web/MemberReplyControllerTest.java
+++ b/src/test/java/net/mureng/mureng/member/web/MemberReplyControllerTest.java
@@ -1,0 +1,57 @@
+package net.mureng.mureng.member.web;
+
+import net.mureng.mureng.annotation.WithMockMurengUser;
+import net.mureng.mureng.common.EntityCreator;
+import net.mureng.mureng.member.entity.Member;
+import net.mureng.mureng.reply.entity.Reply;
+import net.mureng.mureng.reply.service.ReplyService;
+import net.mureng.mureng.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberReplyControllerTest extends AbstractControllerTest {
+    @MockBean
+    ReplyService replyService;
+
+    @Test
+    @WithMockMurengUser
+    public void 사용자_답변_목록_조회_테스트() throws Exception {
+        Member member = EntityCreator.createMemberEntity();
+        List<Reply> replies = Arrays.asList(EntityCreator.createReplyEntity(), EntityCreator.createReplyEntity());
+
+        given(replyService.findRepliesByMemberId(eq(1L))).willReturn(replies);
+
+        mockMvc.perform(
+                get("/api/member/replies")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 사용자_오늘_답변했는지_테스트() throws Exception {
+        given(replyService.isAlreadyReplied(eq(1L))).willReturn(true);
+
+        mockMvc.perform(
+                get("/api/member/check-replied-today")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replied").value(true))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
- 프론트 요청으로 현재 로그인한 사용자를 조회할 수 있는 엔드포인트 추가
- 사용자 컨트롤러 로부터 사용자 답변 컨트롤러를 분리