### PR TITLE
[기능] 답변 상세 조회

### DIFF
--- a/src/main/java/net/mureng/mureng/member/web/MemberReplyController.java
+++ b/src/main/java/net/mureng/mureng/member/web/MemberReplyController.java
@@ -8,22 +8,17 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.mureng.mureng.core.annotation.CurrentUser;
 import net.mureng.mureng.core.dto.ApiResult;
-import net.mureng.mureng.core.jwt.dto.TokenDto;
-import net.mureng.mureng.core.oauth2.dto.OAuth2Profile;
-import net.mureng.mureng.core.oauth2.service.OAuth2Service;
-import net.mureng.mureng.member.component.MemberMapper;
-import net.mureng.mureng.member.dto.MemberDto;
 import net.mureng.mureng.member.entity.Member;
-import net.mureng.mureng.member.service.MemberService;
-import net.mureng.mureng.member.service.MemberSignupService;
 import net.mureng.mureng.reply.component.ReplyMapper;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.service.ReplyService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
-import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,13 +30,14 @@ public class MemberReplyController {
     private final ReplyService replyService;
     private final ReplyMapper replyMapper;
 
-    @ApiOperation(value = "사용자가 답변한 질문 목록 조회", notes = "사용자가 답변한 질문 목록을 가져옵니다.")
-    @GetMapping("/replies")
+    @ApiOperation(value = "사용자 답변 목록 조회", notes = "사용자의 답변 목록을 가져옵니다.")
+    @GetMapping("/{memberId}/replies")
     public ResponseEntity<ApiResult<List<ReplyDto.ReadOnly>>> getQuestionMemberReplied(
-            @CurrentUser Member member){
+            @ApiParam(value = "사용자 id", required = true)
+            @PathVariable Long memberId){
         return ResponseEntity.ok(
                 ApiResult.ok(
-                        replyService.findRepliesByMemberId(member.getMemberId()).stream()
+                        replyService.findRepliesByMemberId(memberId).stream()
                         .map(replyMapper::toDto)
                         .collect(Collectors.toList())
                 )

--- a/src/main/java/net/mureng/mureng/reply/service/ReplyService.java
+++ b/src/main/java/net/mureng/mureng/reply/service/ReplyService.java
@@ -1,9 +1,8 @@
 package net.mureng.mureng.reply.service;
 
 import lombok.RequiredArgsConstructor;
-import net.mureng.mureng.core.dto.ApiPageRequest;
-import net.mureng.mureng.core.exception.AccessNotAllowedException;
 import net.mureng.mureng.core.component.FileUploader;
+import net.mureng.mureng.core.dto.ApiPageRequest;
 import net.mureng.mureng.core.exception.AccessNotAllowedException;
 import net.mureng.mureng.core.exception.BadRequestException;
 import net.mureng.mureng.core.exception.ResourceNotFoundException;
@@ -13,9 +12,6 @@ import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.reply.repository.ReplyRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -131,5 +127,10 @@ public class ReplyService {
     @Transactional(readOnly = true)
     public List<Reply> findRepliesByMemberId(Long memberId){
         return replyRepository.findAllByAuthorMemberId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public Reply findById(Long replyId){
+        return replyRepository.findById(replyId).orElseThrow(() -> new BadRequestException("존재하지 않는 답변에 대한 요청입니다."));
     }
 }

--- a/src/test/java/net/mureng/mureng/member/web/MemberReplyControllerTest.java
+++ b/src/test/java/net/mureng/mureng/member/web/MemberReplyControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -34,7 +33,7 @@ class MemberReplyControllerTest extends AbstractControllerTest {
         given(replyService.findRepliesByMemberId(eq(1L))).willReturn(replies);
 
         mockMvc.perform(
-                get("/api/member/replies")
+                get("/api/member/{memberId}/replies", 1)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))

--- a/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
+++ b/src/test/java/net/mureng/mureng/reply/web/ReplyControllerTest.java
@@ -3,9 +3,6 @@ package net.mureng.mureng.reply.web;
 import net.mureng.mureng.annotation.WithMockMurengUser;
 import net.mureng.mureng.common.EntityCreator;
 import net.mureng.mureng.core.dto.ApiPageRequest;
-import net.mureng.mureng.member.entity.Member;
-import net.mureng.mureng.question.entity.Question;
-import net.mureng.mureng.question.entity.WordHint;
 import net.mureng.mureng.reply.entity.Reply;
 import net.mureng.mureng.reply.service.ReplyService;
 import net.mureng.mureng.web.AbstractControllerTest;
@@ -17,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -73,6 +69,23 @@ public class ReplyControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyLikeCount").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].question.content").value("This is english content."))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].author.nickname").value("Test"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_상세_조회_테스트() throws Exception {
+        given(replyService.findById(eq(REPLY_ID))).willReturn(EntityCreator.createReplyEntity());
+
+        mockMvc.perform(
+                get("/api/reply/{replyId}", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("Test Reply"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyLikeCount").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.question.content").value("This is english content."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.author.nickname").value("Test"))
                 .andDo(print());
     }
 


### PR DESCRIPTION
답변 상세 조회 기능 추가
- /api/reply/{replyId}

다른 사용자의 프로필에서 답변 목록을 가져오는 경우도 존재하므로, 사용자의 답변 목록 엔드포인트 수정
- /api/member/replies -> /api/member/{memberId}/replies