### PR TITLE
[보완] ReplyMapper 엔티티 변환 메서드 추가

### DIFF
--- a/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
+++ b/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
@@ -4,11 +4,11 @@ import net.mureng.mureng.core.component.EntityMapper;
 import net.mureng.mureng.member.component.MemberMapper;
 import net.mureng.mureng.member.entity.Member;
 import net.mureng.mureng.question.component.QuestionMapper;
+import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.entity.Reply;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class })
 public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
@@ -36,4 +36,24 @@ public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
     @Mapping(target = "regDate", ignore = true)
     @Mapping(target = "replyLikes", ignore = true)
     Reply toEntity(ReplyDto replyDto);
+
+    @Mapping(target = "replyId", ignore = true)
+    @Mapping(target = "visible", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "modDate", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    @Mapping(target = "replyLikes", ignore = true)
+    @Mapping(target = "image", expression = "java(replyDto.getImage())")
+    @Mapping(target = "content", expression = "java(replyDto.getContent())")
+    @Mapping(source = "replyDto.questionId", target = "question.questionId")
+    Reply toEntity(ReplyDto replyDto, Member author, Question question);
+
+    @Mapping(target = "question", ignore = true)
+    @Mapping(target = "visible", ignore = true)
+    @Mapping(target = "deleted", ignore = true)
+    @Mapping(target = "modDate", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    @Mapping(target = "replyLikes", ignore = true)
+    @Mapping(target = "image", expression = "java(replyDto.getImage())")
+    Reply toEntity(ReplyDto replyDto, Member author, Long replyId);
 }

--- a/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
+++ b/src/main/java/net/mureng/mureng/reply/component/ReplyMapper.java
@@ -45,7 +45,7 @@ public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
     @Mapping(target = "replyLikes", ignore = true)
     @Mapping(target = "image", expression = "java(replyDto.getImage())")
     @Mapping(target = "content", expression = "java(replyDto.getContent())")
-    @Mapping(source = "replyDto.questionId", target = "question.questionId")
+    @Mapping(source = "question", target = "question")
     Reply toEntity(ReplyDto replyDto, Member author, Question question);
 
     @Mapping(target = "question", ignore = true)

--- a/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
+++ b/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
@@ -53,9 +53,7 @@ public class ReplyController {
         public ResponseEntity<ApiResult<ReplyDto.ReadOnly>> create(@CurrentUser Member member,
                 @RequestBody @Valid ReplyDto replyDto){
 
-            Reply newReply = replyMapper.toEntity(replyDto);
-            newReply.setAuthor(member);
-            newReply.setQuestion(Question.builder().questionId(replyDto.getQuestionId()).build());
+            Reply newReply = replyMapper.toEntity(replyDto, member, Question.builder().build());
 
             return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.create(newReply), member
@@ -68,9 +66,7 @@ public class ReplyController {
                                             @RequestBody @Valid ReplyDto replyDto,
                                             @PathVariable @NotNull Long replyId){
 
-        Reply newReply = replyMapper.toEntity(replyDto);
-        newReply.setAuthor(member);
-        newReply.setReplyId(replyId);
+        Reply newReply = replyMapper.toEntity(replyDto, member, replyId);
 
         return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.update(newReply), member

--- a/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
+++ b/src/main/java/net/mureng/mureng/reply/web/ReplyController.java
@@ -53,7 +53,7 @@ public class ReplyController {
         public ResponseEntity<ApiResult<ReplyDto.ReadOnly>> create(@CurrentUser Member member,
                 @RequestBody @Valid ReplyDto replyDto){
 
-            Reply newReply = replyMapper.toEntity(replyDto, member, Question.builder().build());
+            Reply newReply = replyMapper.toEntity(replyDto, member, Question.builder().questionId(replyDto.getQuestionId()).build());
 
             return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.create(newReply), member

--- a/src/test/java/net/mureng/mureng/common/EntityCreator.java
+++ b/src/test/java/net/mureng/mureng/common/EntityCreator.java
@@ -57,6 +57,7 @@ public class EntityCreator {
                 .memberId(MEMBER_ID)
                 .identifier("123")
                 .email("test@email.com")
+                .image("test-image")
                 .isActive(true)
                 .nickname("Test")
                 .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))

--- a/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
+++ b/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
@@ -51,7 +51,8 @@ class ReplyMapperTest {
 
     @Test
     public void DTO에서_엔티티변환_답변생성할때_테스트() {
-        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), Question.builder().build());
+        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), Question.builder().questionId(replyDto.getQuestionId()).build());
+        assertEquals(replyDto.getQuestionId(), mappedEntity.getQuestion().getQuestionId());
         assertEquals(reply.getContent(), mappedEntity.getContent());
         assertEquals(reply.getAuthor().getEmail(), mappedEntity.getAuthor().getEmail());
     }

--- a/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
+++ b/src/test/java/net/mureng/mureng/reply/component/ReplyMapperTest.java
@@ -1,15 +1,15 @@
 package net.mureng.mureng.reply.component;
 
 import net.mureng.mureng.common.EntityCreator;
+import net.mureng.mureng.question.entity.Question;
 import net.mureng.mureng.reply.dto.ReplyDto;
 import net.mureng.mureng.reply.entity.Reply;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import javax.swing.text.html.parser.Entity;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
 class ReplyMapperTest {
@@ -25,7 +25,6 @@ class ReplyMapperTest {
         ReplyDto.ReadOnly mappedDto = replyMapper.toDto(reply);
         assertEquals(replyDto.getReplyId(), mappedDto.getReplyId());
         assertEquals(replyDto.getContent(), mappedDto.getContent());
-        assertEquals(replyDto.getContent(), mappedDto.getContent());
         assertEquals(replyDto.getAuthor().getMemberId(), mappedDto.getAuthor().getMemberId());
         assertEquals(replyDto.getQuestion().getQuestionId(), mappedDto.getQuestion().getQuestionId());
         assertEquals(replyDto.getReplyLikeCount(), mappedDto.getReplyLikeCount());
@@ -36,7 +35,6 @@ class ReplyMapperTest {
     public void 엔티티에서_DTO변환_로그인사용자_테스트() {
         ReplyDto.ReadOnly mappedDto = replyMapper.toDto(reply, EntityCreator.createMemberEntity());
         assertEquals(replyDto.getReplyId(), mappedDto.getReplyId());
-        assertEquals(replyDto.getContent(), mappedDto.getContent());
         assertEquals(replyDto.getContent(), mappedDto.getContent());
         assertEquals(replyDto.getAuthor().getMemberId(), mappedDto.getAuthor().getMemberId());
         assertEquals(replyDto.getQuestion().getQuestionId(), mappedDto.getQuestion().getQuestionId());
@@ -49,6 +47,21 @@ class ReplyMapperTest {
         Reply mappedEntity = replyMapper.toEntity(replyDto);
         assertEquals(reply.getContent(), mappedEntity.getContent());
         assertEquals(reply.getImage(), mappedEntity.getImage());
+    }
+
+    @Test
+    public void DTO에서_엔티티변환_답변생성할때_테스트() {
+        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), Question.builder().build());
+        assertEquals(reply.getContent(), mappedEntity.getContent());
+        assertEquals(reply.getAuthor().getEmail(), mappedEntity.getAuthor().getEmail());
+    }
+
+    @Test
+    public void DTO에서_엔티티변환_답변수정할때_테스트() {
+        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), 2L);
+        assertEquals(2L, mappedEntity.getReplyId());
+        assertEquals(reply.getContent(), mappedEntity.getContent());
+        assertEquals(reply.getAuthor().getEmail(), mappedEntity.getAuthor().getEmail());
     }
 
 }


### PR DESCRIPTION
컨트롤러 단에서 reply Entity에 setter를 통해 추가했던 것을, ReplyMapper로 처리할 수 있도록 변경