### PR TITLE
[기능] 답변 좋아요

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
@@ -1,0 +1,25 @@
+package net.mureng.api.reply.component;
+
+import net.mureng.api.core.component.EntityMapper;
+import net.mureng.api.member.component.MemberMapper;
+import net.mureng.api.reply.dto.ReplyLikesDto;
+import net.mureng.core.reply.entity.ReplyLikes;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = { ReplyMapper.class, MemberMapper.class })
+public interface ReplyLikesMapper extends EntityMapper<ReplyLikes, ReplyLikesDto> {
+
+    @Override
+    @Mapping(source = "replyLikes.member.memberId", target = "memberId")
+    @Mapping(source = "replyLikes.reply.replyId", target = "replyId")
+    @Mapping(target = "likes", ignore = true)
+    ReplyLikesDto toDto(ReplyLikes replyLikes);
+
+    @Override
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "member", ignore = true)
+    @Mapping(target = "reply", ignore = true)
+    @Mapping(target = "regDate", ignore = true)
+    ReplyLikes toEntity(ReplyLikesDto replyLikesDto);
+}

--- a/mureng-api/src/main/java/net/mureng/api/reply/dto/ReplyLikesDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/dto/ReplyLikesDto.java
@@ -1,0 +1,28 @@
+package net.mureng.api.reply.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value="답변 좋아요 모델", description="답변 좋아요를 나타내는 모델")
+public class ReplyLikesDto {
+    @ApiModelProperty(value = "사용자 id", position = PropertyDisplayOrder.MEMBER_ID)
+    private Long memberId;
+
+    @ApiModelProperty(value = "답변 id", position = PropertyDisplayOrder.REPLY_ID)
+    private Long replyId;
+
+    @Builder.Default
+    @ApiModelProperty(value = "좋아요", position = PropertyDisplayOrder.LIKES)
+    private boolean likes = true;
+
+    private static class PropertyDisplayOrder {
+        private static final int MEMBER_ID    = 0;
+        private static final int REPLY_ID     = 1;
+        private static final int LIKES        = 2;
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyController.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyController.java
@@ -3,6 +3,8 @@ package net.mureng.api.reply.web;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.mureng.api.core.annotation.CurrentUser;
 import net.mureng.api.core.dto.ApiPageRequest;
@@ -17,6 +19,7 @@ import net.mureng.core.reply.entity.Reply;
 import net.mureng.core.reply.service.ReplyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -77,9 +80,16 @@ public class ReplyController {
 
     @ApiOperation(value = "답변 삭제하기", notes = "답변을 삭제합니다.")
     @DeleteMapping("/{replyId}")
-    public ResponseEntity<ApiResult<Boolean>> deleteReply(@CurrentUser Member member,
+    public ResponseEntity<ApiResult<DeletedDto>> deleteReply(@CurrentUser Member member,
                                                           @PathVariable @NotNull Long replyId){
         replyService.delete(member, replyId);
-        return ResponseEntity.ok(ApiResult.ok(true));
+        return ResponseEntity.ok(ApiResult.ok(new DeletedDto(true)));
+    }
+
+    @ApiIgnore
+    @AllArgsConstructor
+    @Getter
+    public static class DeletedDto{
+        private final boolean deleted;
     }
 }

--- a/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyLikesController.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyLikesController.java
@@ -1,0 +1,47 @@
+package net.mureng.api.reply.web;
+
+import io.swagger.annotations.Api;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.mureng.api.core.annotation.CurrentUser;
+import net.mureng.api.core.dto.ApiResult;
+import net.mureng.api.reply.component.ReplyLikesMapper;
+import net.mureng.core.member.entity.Member;
+import net.mureng.core.reply.service.ReplyLikesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Api(value = "답변 좋아요 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reply")
+public class ReplyLikesController {
+
+    private final ReplyLikesService replyLikesService;
+    private final ReplyLikesMapper replyLikesMapper;
+
+    @PostMapping("/{replyId}/reply-likes")
+    public ResponseEntity<ApiResult> postReplyLikes(@CurrentUser Member member, @PathVariable Long replyId){
+        return ResponseEntity.ok(ApiResult.ok(
+                replyLikesMapper.toDto(
+                        replyLikesService.postReplyLikes(member, replyId)
+                )
+        ));
+    }
+
+    @DeleteMapping("/{replyId}/reply-likes")
+    public ResponseEntity<ApiResult<DeletedDto>> deleteReplyLikes(@CurrentUser Member member, @PathVariable Long replyId){
+        replyLikesService.deleteReplyLikes(member, replyId);
+        return ResponseEntity.ok(ApiResult.ok(new DeletedDto(true)));
+    }
+
+    @ApiIgnore
+    @AllArgsConstructor
+    @Getter
+    public static class DeletedDto{
+        private final boolean deleted;
+    }
+
+}

--- a/mureng-api/src/test/java/net/mureng/api/common/DtoCreator.java
+++ b/mureng-api/src/test/java/net/mureng/api/common/DtoCreator.java
@@ -4,6 +4,7 @@ import net.mureng.api.member.dto.MemberDto;
 import net.mureng.api.question.dto.QuestionDto;
 import net.mureng.api.question.dto.WordHintDto;
 import net.mureng.api.reply.dto.ReplyDto;
+import net.mureng.api.reply.dto.ReplyLikesDto;
 
 import java.util.Set;
 
@@ -47,6 +48,13 @@ public class DtoCreator {
                 .image("image-path")
                 .replyLikeCount(2)
                 .requestedByAuthor(true)
+                .build();
+    }
+
+    public static ReplyLikesDto createReplyLikesDto(){
+        return ReplyLikesDto.builder()
+                .replyId(1L)
+                .memberId(1L)
                 .build();
     }
 

--- a/mureng-api/src/test/java/net/mureng/api/reply/component/ReplyLikesMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/reply/component/ReplyLikesMapperTest.java
@@ -1,0 +1,30 @@
+package net.mureng.api.reply.component;
+
+import net.mureng.api.common.DtoCreator;
+import net.mureng.api.reply.dto.ReplyLikesDto;
+import net.mureng.core.common.EntityCreator;
+import net.mureng.core.reply.entity.ReplyLikes;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class ReplyLikesMapperTest {
+
+    @Autowired
+    private ReplyLikesMapper replyLikesMapper;
+
+    private final ReplyLikes replyLikes = EntityCreator.createReplyLikesEntity();
+    private final ReplyLikesDto replyLikesDto = DtoCreator.createReplyLikesDto();
+
+    @Test
+    public void 엔티티에서_DTO변환_테스트() {
+        ReplyLikesDto mappedDto = replyLikesMapper.toDto(replyLikes);
+        assertEquals(replyLikesDto.getReplyId(), mappedDto.getReplyId());
+        assertEquals(replyLikesDto.getMemberId(), mappedDto.getMemberId());
+        assertTrue(mappedDto.isLikes());
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyLikesControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyLikesControllerTest.java
@@ -1,0 +1,40 @@
+package net.mureng.api.reply.web;
+
+import net.mureng.api.annotation.WithMockMurengUser;
+import net.mureng.api.web.AbstractControllerTest;
+import net.mureng.core.common.EntityCreator;
+import net.mureng.core.reply.service.ReplyLikesService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ReplyLikesControllerTest extends AbstractControllerTest {
+    @MockBean
+    private ReplyLikesService replyLikesService;
+
+    private static final long REPLY_ID = 1L;
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_좋아요_등록_테스트() throws Exception {
+        given(replyLikesService.postReplyLikes(any(), eq(REPLY_ID))).willReturn(EntityCreator.createReplyLikesEntity());
+
+        mockMvc.perform(
+                post("/api/reply/{replyId}/reply-likes", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.likes").value(true))
+                .andDo(print());
+    }
+}

--- a/mureng-core/src/main/java/net/mureng/core/reply/entity/ReplyLikesPK.java
+++ b/mureng-core/src/main/java/net/mureng/core/reply/entity/ReplyLikesPK.java
@@ -29,7 +29,6 @@ public class ReplyLikesPK implements Serializable {
     }
 
     @Builder
-
     public ReplyLikesPK(Long replyId, Long memberId) {
         this.replyId = replyId;
         this.memberId = memberId;

--- a/mureng-core/src/main/java/net/mureng/core/reply/repository/ReplyLikesRepository.java
+++ b/mureng-core/src/main/java/net/mureng/core/reply/repository/ReplyLikesRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReplyLikesRepository extends JpaRepository<ReplyLikes, ReplyLikesPK> {
     int countByIdReplyId(Long replyId);
+    Boolean existsByMemberMemberIdAndReplyReplyId(Long memberId, Long replyId);
 }

--- a/mureng-core/src/main/java/net/mureng/core/reply/service/ReplyLikesService.java
+++ b/mureng-core/src/main/java/net/mureng/core/reply/service/ReplyLikesService.java
@@ -1,0 +1,47 @@
+package net.mureng.core.reply.service;
+
+import lombok.RequiredArgsConstructor;
+import net.mureng.core.core.exception.BadRequestException;
+import net.mureng.core.core.exception.ResourceNotFoundException;
+import net.mureng.core.member.entity.Member;
+import net.mureng.core.reply.entity.Reply;
+import net.mureng.core.reply.entity.ReplyLikes;
+import net.mureng.core.reply.entity.ReplyLikesPK;
+import net.mureng.core.reply.repository.ReplyLikesRepository;
+import net.mureng.core.reply.repository.ReplyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyLikesService {
+    private final ReplyLikesRepository replyLikesRepository;
+    private final ReplyRepository replyRepository;
+
+    @Transactional
+    public ReplyLikes postReplyLikes(Member member, Long replyId){
+        Reply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변에 대한 요청입니다."));
+
+        if(replyLikesRepository.existsByMemberMemberIdAndReplyReplyId(member.getMemberId(), reply.getReplyId()))
+            throw new BadRequestException("이미 좋아요를 눌렀습니다.");
+
+        ReplyLikes replyLikes = ReplyLikes.builder().member(member).reply(reply).build();
+
+        return replyLikesRepository.saveAndFlush(replyLikes);
+    }
+
+    @Transactional
+    public void deleteReplyLikes(Member member, Long replyId){
+        Reply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변에 대한 요청입니다."));
+
+        if(!replyLikesRepository.existsByMemberMemberIdAndReplyReplyId(member.getMemberId(), reply.getReplyId()))
+            throw new BadRequestException("이미 좋아요를 취소했습니다.");
+
+        ReplyLikesPK replyLikesPK = new ReplyLikesPK(member.getMemberId(), reply.getReplyId());
+
+        replyLikesRepository.deleteById(replyLikesPK);
+    }
+
+}

--- a/mureng-core/src/test/java/net/mureng/core/common/EntityCreator.java
+++ b/mureng-core/src/test/java/net/mureng/core/common/EntityCreator.java
@@ -64,7 +64,7 @@ public class EntityCreator {
     public static ReplyLikes createReplyLikesEntity() {
         return ReplyLikes.builder()
                 .member(createMemberEntity())
-//                .reply(createReplyEntity())
+                .reply(Reply.builder().replyId(1L).build())
                 .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))
                 .build();
     }


### PR DESCRIPTION
- ReplyLikesDto 및 ReplyLikesMapper 생성
  - toDto의 경우만 사용하고, toEntity의 경우는 존재하지 않아서 모든 멤버변수에 대해 `ignore = true`를 적용함
- ReplyLikes Controller와 Service 생성
  - post의 경우엔 ReplyLikesDto를 리턴하고, delete의 경우 DeletedDto를 리턴하도록 함 