### PR TITLE
[수정] 파드로부터 아파치 컨테이너 별도의 파드로 분리

### DIFF
--- a/deployment/deployment-dev.yml
+++ b/deployment/deployment-dev.yml
@@ -1,25 +1,10 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: mureng-app-dev
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 8081
-      targetPort: 8080
-      name: mureng-app-port
-    - port: 10025
-      targetPort: 80
-      name: apache-port
-  selector:
-    app: mureng-app-dev
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mureng-app-dev-deployment
 spec:
   replicas: 2
+  minReadySeconds: 20
   selector:
     matchLabels:
       app: mureng-app-dev
@@ -36,8 +21,8 @@ spec:
               memory: "512Mi"
               cpu: "1000m"
             limits:
-              memory: "1024Mi"
-              cpu: "1500m"
+              memory: "512Mi"
+              cpu: "1000m"
           volumeMounts:
             - name: content-server-volume
               mountPath: /home/gradle/mount
@@ -54,20 +39,6 @@ spec:
               value: "$DEV_DB_USERNAME"
             - name: SPRING_DATASOURCE_PASSWORD
               value: "$DEV_DB_PASSWORD"
-        - name: apache
-          image: httpd
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "300m"
-            limits:
-              memory: "512Mi"
-              cpu: "500m"
-          volumeMounts:
-            - name: content-server-volume
-              mountPath: /usr/local/apache2/htdocs
-          ports:
-            - containerPort: 80
       volumes:
         - name: content-server-volume
           hostPath:


### PR DESCRIPTION
인프라 수정:
기존 - 머랭앱과 컨테이너를 하나의 파드에 배포
개선 - 머랭앱과 컨테이너를 각각의 파드로 분리