### PR TITLE
[기능] 사용자 성과 페이지

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/badge/component/BadgeMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/badge/component/BadgeMapper.java
@@ -1,0 +1,10 @@
+package net.mureng.api.badge.component;
+
+import net.mureng.api.badge.dto.BadgeDto;
+import net.mureng.core.badge.entity.Badge;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BadgeMapper {
+    BadgeDto toDto(Badge badge);
+}

--- a/mureng-api/src/main/java/net/mureng/api/badge/dto/BadgeDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/badge/dto/BadgeDto.java
@@ -1,0 +1,27 @@
+package net.mureng.api.badge.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+
+@Builder
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ApiModel(value="뱃지 모델", description="뱃지 모델")
+public class BadgeDto {
+    @ApiModelProperty(value = "뱃지 이름")
+    @JsonProperty(index = PropertyDisplayOrder.NAME)
+    private String name;
+
+    @ApiModelProperty(value = "뱃지 내용")
+    @JsonProperty(index = PropertyDisplayOrder.CONTENT)
+    private String content;
+
+    private static class PropertyDisplayOrder {
+        private static final int NAME                = 0;
+        private static final int CONTENT             = 1;
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/core/oauth2/service/OAuth2Service.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/oauth2/service/OAuth2Service.java
@@ -27,12 +27,12 @@ public class OAuth2Service {
     public OAuth2Profile getProfile(String provider, String accessToken) throws JsonProcessingException {
         JsonNode json = getJsonResponse(provider, accessToken);
 
-        if(provider == "kakao")
+        if(provider.equals("kakao"))
             return setKakaoProfile(json);
-        else if(provider == "google")
+        else if(provider.equals("google"))
             return setGoogleProfile(json);
         else
-            throw new BadRequestException("잘못된 provider입니다.");
+            throw new BadRequestException("잘못된 provider 입니다.");
     }
 
     public JsonNode getJsonResponse(String provider, String accessToken) throws JsonProcessingException, HttpClientErrorException {

--- a/mureng-api/src/main/java/net/mureng/api/member/component/MemberAchievementMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/component/MemberAchievementMapper.java
@@ -1,0 +1,17 @@
+package net.mureng.api.member.component;
+
+import net.mureng.api.badge.component.BadgeMapper;
+import net.mureng.api.member.dto.MemberAchievementDto;
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.member.entity.Member;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = {MemberMapper.class, BadgeMapper.class})
+public interface MemberAchievementMapper {
+
+    @Mapping(target = "requesterProfile", expression = "java(member.isRequesterProfile(loggedInMember.getMemberId()))")
+    MemberAchievementDto toDto(Member member, List<Badge> badges, Member loggedInMember);
+}

--- a/mureng-api/src/main/java/net/mureng/api/member/component/MemberScrapMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/component/MemberScrapMapper.java
@@ -1,6 +1,6 @@
 package net.mureng.api.member.component;
 
-import net.mureng.api.member.dto.MemberProfileDto;
+import net.mureng.api.member.dto.MemberScrapDto;
 import net.mureng.api.todayexpression.component.TodayExpressionMapper;
 import net.mureng.core.member.entity.Member;
 import net.mureng.core.todayexpression.entity.TodayExpression;
@@ -11,10 +11,10 @@ import org.mapstruct.Mapping;
 import java.util.List;
 
 @Mapper(componentModel = "spring",  uses = { MemberMapper.class, TodayExpressionMapper.class})
-public interface MemberProfileMapper {
+public interface MemberScrapMapper {
 
     @Mapping(source = "member", target = "member")
     @Mapping(source = "scrapList", target = "scrapList")
     @Mapping(target = "requesterProfile", expression = "java(member.isRequesterProfile(loggedInMember.getMemberId()))")
-    MemberProfileDto toDto(Member member, List<TodayExpression> scrapList, @Context Member loggedInMember);
+    MemberScrapDto toDto(Member member, List<TodayExpression> scrapList, @Context Member loggedInMember);
 }

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
@@ -22,8 +22,13 @@ public class MemberAchievementDto {
     @JsonProperty(index = PropertyDisplayOrder.BADGES)
     private List<BadgeDto> badges;
 
+    @ApiModelProperty(value = "요청자의 프로필인지")
+    @JsonProperty(index = PropertyDisplayOrder.REQUESTER_PROFILE)
+    private boolean requesterProfile;
+
     private static class PropertyDisplayOrder {
         private static final int MEMBER                = 0;
-        private static final int BADGES = 1;
+        private static final int BADGES                = 1;
+        private static final int REQUESTER_PROFILE     = 2;
     }
 }

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
@@ -1,0 +1,29 @@
+package net.mureng.api.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import net.mureng.api.badge.dto.BadgeDto;
+
+import java.util.List;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value="사용자 성과 모델", description="사용자 프로필 성과 모델")
+public class MemberAchievementDto {
+    @ApiModelProperty(value = "사용자 정보")
+    @JsonProperty(index = PropertyDisplayOrder.MEMBER)
+    private MemberDto member;
+
+    @ApiModelProperty(value = "사용자 뱃지 목록")
+    @JsonProperty(index = PropertyDisplayOrder.BADGES)
+    private List<BadgeDto> badges;
+
+    private static class PropertyDisplayOrder {
+        private static final int MEMBER                = 0;
+        private static final int BADGES = 1;
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberDto.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 @SuperBuilder
 @Getter @Setter
@@ -18,17 +18,18 @@ import javax.validation.constraints.NotEmpty;
 @AllArgsConstructor
 @ApiModel(value="회원 모델", description="회원을 나타내는 모델")
 public class MemberDto {
-    @NotEmpty
+    @NotBlank
     @ApiModelProperty(value = "회원 식별값", required = true, position = PropertyDisplayOrder.IDENTIFIER)
     @JsonProperty(index = PropertyDisplayOrder.IDENTIFIER)
     private String identifier;
 
     @Email
+    @NotBlank
     @ApiModelProperty(value = "이메일 주소", required = true, position = PropertyDisplayOrder.EMAIL)
     @JsonProperty(index = PropertyDisplayOrder.EMAIL)
     private String email;
 
-    @NotEmpty
+    @NotBlank
     @ApiModelProperty(value = "닉네임", required = true, position = PropertyDisplayOrder.NICKNAME)
     @JsonProperty(index = PropertyDisplayOrder.NICKNAME)
     private String nickname;

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberScrapDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberScrapDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(value="회원 프로필 모델", description="회원 프로필을 나타내는 모델")
+@ApiModel(value="사용자 스크랩 모델", description="사용자 프로필 스크랩 모델")
 public class MemberScrapDto {
     @ApiModelProperty(value = "사용자 정보")
     @JsonProperty(index = PropertyDisplayOrder.MEMBER)

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberScrapDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberScrapDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel(value="회원 프로필 모델", description="회원 프로필을 나타내는 모델")
-public class MemberProfileDto {
+public class MemberScrapDto {
     @ApiModelProperty(value = "사용자 정보")
     @JsonProperty(index = PropertyDisplayOrder.MEMBER)
     private MemberDto member;

--- a/mureng-api/src/main/java/net/mureng/api/member/service/MemberBadgeService.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/service/MemberBadgeService.java
@@ -1,0 +1,20 @@
+package net.mureng.api.member.service;
+
+import lombok.RequiredArgsConstructor;
+import net.mureng.core.badge.entity.BadgeAccomplished;
+import net.mureng.core.badge.repository.BadgeAccomplishedRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberBadgeService {
+    private final BadgeAccomplishedRepository badgeAccomplishedRepository;
+
+    @Transactional(readOnly = true)
+    public List<BadgeAccomplished> getMemberBadges(Long memberId){
+        return badgeAccomplishedRepository.findBadgeAccomplishedsByIdMemberId(memberId);
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/member/web/MemberAchievementController.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/web/MemberAchievementController.java
@@ -1,0 +1,44 @@
+package net.mureng.api.member.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import net.mureng.api.core.annotation.CurrentUser;
+import net.mureng.api.core.dto.ApiResult;
+import net.mureng.api.member.component.MemberAchievementMapper;
+import net.mureng.api.member.dto.MemberAchievementDto;
+import net.mureng.api.member.service.MemberBadgeService;
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.badge.entity.BadgeAccomplished;
+import net.mureng.core.member.entity.Member;
+import net.mureng.core.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api(value = "사용자 성과 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberAchievementController {
+    private final MemberBadgeService memberBadgeService;
+    private final MemberAchievementMapper memberAchievementMapper;
+    private final MemberService memberService;
+
+    @ApiOperation(value = "사용자의 성과 페이지", notes = "사용자의 뱃지 목록을 가져옵니다.")
+    @GetMapping("/{memberId}/achievement")
+    public ResponseEntity<ApiResult<MemberAchievementDto>> getMemberAchievement(@CurrentUser Member member, @PathVariable Long memberId) {
+
+        List<Badge> badges = memberBadgeService.getMemberBadges(memberId).stream().map(BadgeAccomplished::getBadge).collect(Collectors.toList());
+        Member profileMember = memberService.findById(memberId);
+
+        return ResponseEntity.ok(ApiResult.ok(
+                memberAchievementMapper.toDto(profileMember, badges, member)
+        ));
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/member/web/MemberScrapController.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/web/MemberScrapController.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.mureng.api.core.annotation.CurrentUser;
 import net.mureng.api.core.dto.ApiResult;
-import net.mureng.api.member.component.MemberProfileMapper;
-import net.mureng.api.member.dto.MemberProfileDto;
+import net.mureng.api.member.component.MemberScrapMapper;
+import net.mureng.api.member.dto.MemberScrapDto;
 import net.mureng.api.member.service.MemberExpressionScrapService;
 import net.mureng.api.todayexpression.component.TodayExpressionMapper;
 import net.mureng.api.todayexpression.dto.TodayExpressionDto;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public class MemberScrapController {
     private final MemberExpressionScrapService memberExpressionScrapService;
     private final TodayExpressionMapper todayExpressionMapper;
-    private final MemberProfileMapper memberProfileMapper;
+    private final MemberScrapMapper memberScrapMapper;
     private final MemberService memberService;
 
     @ApiOperation(value = "오늘의 표현 스크랩", notes = "오늘의 표현을 스크랩합니다.")
@@ -52,13 +52,13 @@ public class MemberScrapController {
 
     @ApiOperation(value = "사용자의 스크랩 목록 가져오기", notes = "사용자의 스크랩 목록을 가져옵니다.")
     @GetMapping("/{memberId}/scrap")
-    public ResponseEntity<ApiResult<MemberProfileDto>> getMemberScrap(@CurrentUser Member member, @PathVariable Long memberId){
+    public ResponseEntity<ApiResult<MemberScrapDto>> getMemberScrap(@CurrentUser Member member, @PathVariable Long memberId){
 
         List<MemberScrap> scrapList = memberExpressionScrapService.getMemberScrap(memberId);
         Member profileMember = memberService.findById(memberId);
 
         return ResponseEntity.ok(ApiResult.ok(
-                memberProfileMapper.toDto(
+                memberScrapMapper.toDto(
                         profileMember,
                         scrapList.stream().map(MemberScrap::getTodayExpression).collect(Collectors.toList()),
                         member)
@@ -67,13 +67,13 @@ public class MemberScrapController {
 
     @ApiOperation(value = "내 스크랩 목록 가져오기", notes ="나의 스크랩 목록을 가져옵니다.")
     @GetMapping("/me/scrap")
-    public ResponseEntity<ApiResult<MemberProfileDto>> getMyScrap(@CurrentUser Member member){
+    public ResponseEntity<ApiResult<MemberScrapDto>> getMyScrap(@CurrentUser Member member){
         long memberId = member.getMemberId();
 
         List<MemberScrap> scrapList = memberExpressionScrapService.getMemberScrap(memberId);
 
         return ResponseEntity.ok(ApiResult.ok(
-                memberProfileMapper.toDto(
+                memberScrapMapper.toDto(
                         member,
                         scrapList.stream().map(MemberScrap::getTodayExpression).collect(Collectors.toList()),
                         member)

--- a/mureng-api/src/test/java/net/mureng/api/badge/BadgeMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/badge/BadgeMapperTest.java
@@ -1,0 +1,30 @@
+package net.mureng.api.badge;
+
+import net.mureng.api.badge.component.BadgeMapper;
+import net.mureng.api.badge.dto.BadgeDto;
+import net.mureng.api.common.DtoCreator;
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.common.EntityCreator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class BadgeMapperTest {
+
+    @Autowired
+    private BadgeMapper badgeMapper;
+
+    private static final Badge badge = EntityCreator.createBadgeEntity();
+    private static final BadgeDto badgeDto = DtoCreator.createBadgeDto();
+
+    @Test
+    public void 엔티티에서_DTO변환_테스트() {
+        BadgeDto mappedDto = badgeMapper.toDto(badge);
+
+        assertEquals(mappedDto.getName(), badgeDto.getName());
+        assertEquals(mappedDto.getContent(), badgeDto.getContent());
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/common/DtoCreator.java
+++ b/mureng-api/src/test/java/net/mureng/api/common/DtoCreator.java
@@ -1,5 +1,6 @@
 package net.mureng.api.common;
 
+import net.mureng.api.badge.dto.BadgeDto;
 import net.mureng.api.member.dto.MemberDto;
 import net.mureng.api.question.dto.QuestionDto;
 import net.mureng.api.question.dto.WordHintDto;
@@ -78,4 +79,12 @@ public class DtoCreator {
                 .scrappedByRequester(false)
                 .build();
     }
+
+    public static BadgeDto createBadgeDto() {
+        return BadgeDto.builder()
+                .name("Badge Test")
+                .content("Badge Test Content")
+                .build();
+    }
+
 }

--- a/mureng-api/src/test/java/net/mureng/api/member/component/MemberAchievementMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/component/MemberAchievementMapperTest.java
@@ -1,0 +1,42 @@
+package net.mureng.api.member.component;
+
+import net.mureng.api.badge.dto.BadgeDto;
+import net.mureng.api.common.DtoCreator;
+import net.mureng.api.member.dto.MemberAchievementDto;
+import net.mureng.api.member.dto.MemberDto;
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.common.EntityCreator;
+import net.mureng.core.member.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@SpringBootTest
+public class MemberAchievementMapperTest {
+
+    @Autowired
+    private MemberAchievementMapper memberAchievementMapper;
+
+    private static final List<Badge> badges = Arrays.asList(EntityCreator.createBadgeEntity(), EntityCreator.createBadgeEntity());
+    private static final List<BadgeDto> badgeDtos = Arrays.asList(DtoCreator.createBadgeDto(), DtoCreator.createBadgeDto());
+
+    private static final Member member = EntityCreator.createMemberEntity();
+    private static final MemberDto memberDto = DtoCreator.createMemberDto();
+
+    @Test
+    public void 엔티티에서_DTO변환_테스트() {
+        MemberAchievementDto mappedDto = memberAchievementMapper.toDto(member, badges, member);
+
+        assertEquals(mappedDto.getMember().getEmail(), memberDto.getEmail());
+        assertEquals(mappedDto.getBadges().size(), badgeDtos.size());
+        assertEquals(mappedDto.getBadges().get(0).getName(), badgeDtos.get(0).getName());
+        assertTrue(mappedDto.isRequesterProfile());
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/member/component/MemberScrapMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/component/MemberScrapMapperTest.java
@@ -2,7 +2,7 @@ package net.mureng.api.member.component;
 
 import net.mureng.api.common.DtoCreator;
 import net.mureng.api.member.dto.MemberDto;
-import net.mureng.api.member.dto.MemberProfileDto;
+import net.mureng.api.member.dto.MemberScrapDto;
 import net.mureng.api.todayexpression.dto.TodayExpressionDto;
 import net.mureng.core.common.EntityCreator;
 import net.mureng.core.member.entity.Member;
@@ -18,9 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
-public class MemberProfileMapperTest {
+public class MemberScrapMapperTest {
     @Autowired
-    private MemberProfileMapper memberProfileMapper;
+    private MemberScrapMapper memberScrapMapper;
 
     private static final MemberDto memberDto = DtoCreator.createMemberDto();
     private static final List<TodayExpressionDto> todayExpressionDtoList = Arrays.asList(DtoCreator.createTodayExpressionDto(), DtoCreator.createTodayExpressionDto());
@@ -29,7 +29,7 @@ public class MemberProfileMapperTest {
 
     @Test
     public void 엔티티에서_DTO변환_테스트() {
-        MemberProfileDto mappedDto = memberProfileMapper.toDto(member, todayExpressionList, member);
+        MemberScrapDto mappedDto = memberScrapMapper.toDto(member, todayExpressionList, member);
         assertEquals(mappedDto.getMember().getEmail(), memberDto.getEmail());
         assertEquals(mappedDto.getScrapList().get(0).getExpression(), todayExpressionDtoList.get(0).getExpression());
         assertTrue(mappedDto.getScrapList().get(0).isScrappedByRequester());

--- a/mureng-api/src/test/java/net/mureng/api/member/web/MemberAchievementControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/web/MemberAchievementControllerTest.java
@@ -1,0 +1,57 @@
+package net.mureng.api.member.web;
+
+import net.mureng.api.annotation.WithMockMurengUser;
+import net.mureng.api.member.service.MemberBadgeService;
+import net.mureng.api.web.AbstractControllerTest;
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.badge.entity.BadgeAccomplished;
+import net.mureng.core.common.EntityCreator;
+import net.mureng.core.member.entity.Member;
+import net.mureng.core.member.service.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MemberAchievementControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    MemberBadgeService memberBadgeService;
+
+    @MockBean
+    MemberService memberService;
+
+    private static final long MEMBER_ID = 1L;
+    private static final List<BadgeAccomplished> badgeAccomplisheds = Arrays.asList(EntityCreator.createBadgeAccomplishedEntity(), EntityCreator.createBadgeAccomplishedEntity());
+
+    private List<Badge> badges = Arrays.asList(EntityCreator.createBadgeEntity(), EntityCreator.createBadgeEntity());
+    private Member member = EntityCreator.createMemberEntity();
+
+    @Test
+    @WithMockMurengUser
+    public void 사용자_성과_가져오기_테스트() throws Exception{
+        given(memberBadgeService.getMemberBadges(eq(MEMBER_ID))).willReturn(badgeAccomplisheds);
+        given(memberService.findById(eq(MEMBER_ID))).willReturn(member);
+
+        mockMvc.perform(
+                get("/api/member/{memberId}/achievement", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.member.memberId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.member.email").value("test@gmail.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.badges[0].name").value("Badge Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.badges[0].content").value("Badge Test Content"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.requesterProfile").value("true"))
+                .andDo(print());
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/oauth/OAuthServiceTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/oauth/OAuthServiceTest.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import net.mureng.api.core.jwt.dto.TokenDto;
 import net.mureng.api.core.oauth2.dto.OAuth2Profile;
 import net.mureng.api.core.oauth2.service.OAuth2Service;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Ignore("개발용 임시 테스트")
 public class OAuthServiceTest {
 
     @Autowired

--- a/mureng-core/src/main/java/net/mureng/core/badge/entity/Badge.java
+++ b/mureng-core/src/main/java/net/mureng/core/badge/entity/Badge.java
@@ -3,10 +3,12 @@ package net.mureng.core.badge.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 
-@Getter
+@Builder
+@Getter @Setter
 @NoArgsConstructor
 @Entity
 @Table(name = "badge")
@@ -23,10 +25,4 @@ public class Badge {
     @Column(nullable = false)
     private String content;
 
-    @Builder
-    public Badge(Long badgeId, String name, String content) {
-        this.badgeId = badgeId;
-        this.name = name;
-        this.content = content;
-    }
 }

--- a/mureng-core/src/main/java/net/mureng/core/badge/entity/Badge.java
+++ b/mureng-core/src/main/java/net/mureng/core/badge/entity/Badge.java
@@ -1,15 +1,13 @@
 package net.mureng.core.badge.entity;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Builder
 @Getter @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "badge")
 public class Badge {

--- a/mureng-core/src/main/java/net/mureng/core/badge/entity/BadgeAccomplished.java
+++ b/mureng-core/src/main/java/net/mureng/core/badge/entity/BadgeAccomplished.java
@@ -3,12 +3,14 @@ package net.mureng.core.badge.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import net.mureng.core.member.entity.Member;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Getter
+@Builder
+@Getter @Setter
 @NoArgsConstructor
 @Entity
 @Table(name = "badge_accomplished")
@@ -27,13 +29,9 @@ public class BadgeAccomplished {
     @JoinColumn(name = "badge_id")
     private Badge badge;
 
+    @Builder.Default
     @Column(name = "reg_date", nullable = false)
     private LocalDateTime regDate = LocalDateTime.now();
 
-    @Builder
-    public BadgeAccomplished(BadgeAccomplishedPK id, LocalDateTime regDate) {
-        this.id = id;
-        this.regDate = regDate;
-    }
 }
 

--- a/mureng-core/src/main/java/net/mureng/core/badge/entity/BadgeAccomplished.java
+++ b/mureng-core/src/main/java/net/mureng/core/badge/entity/BadgeAccomplished.java
@@ -1,9 +1,6 @@
 package net.mureng.core.badge.entity;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.mureng.core.member.entity.Member;
 
 import javax.persistence.*;
@@ -12,6 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 @Getter @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "badge_accomplished")
 public class BadgeAccomplished {

--- a/mureng-core/src/test/java/net/mureng/core/common/EntityCreator.java
+++ b/mureng-core/src/test/java/net/mureng/core/common/EntityCreator.java
@@ -1,5 +1,8 @@
 package net.mureng.core.common;
 
+import net.mureng.core.badge.entity.Badge;
+import net.mureng.core.badge.entity.BadgeAccomplished;
+import net.mureng.core.badge.entity.BadgeAccomplishedPK;
 import net.mureng.core.member.entity.Member;
 import net.mureng.core.member.entity.MemberScrap;
 import net.mureng.core.member.entity.MemberScrapPK;
@@ -114,6 +117,22 @@ public class EntityCreator {
                                                 .member(EntityCreator.createMemberEntity()).build())))
                         .build())
                 .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))
+                .build();
+    }
+
+    public static Badge createBadgeEntity(){
+        return Badge.builder()
+                .badgeId(1L)
+                .name("Badge Test")
+                .content("Badge Test Content")
+                .build();
+    }
+
+    public static BadgeAccomplished createBadgeAccomplishedEntity() {
+        return BadgeAccomplished.builder()
+                .id(new BadgeAccomplishedPK(1L, 1L))
+                .member(EntityCreator.createMemberEntity())
+                .badge(EntityCreator.createBadgeEntity())
                 .build();
     }
 }


### PR DESCRIPTION
- 프론트 요청에 따라 뱃지 엔드포인트가 아닌 성과 엔드포인트로 작성함
- 성과 DTO를 만들어서 제공
- 현재 스크랩, 성과 탭의 경우, 사용자의 수정여부를 제공하고 있지만 기록 탭에서는 제공하고 있지 않음 
  - 즉, 기록 탭에서는 필요한 엔드포인트가 2개, 나머지는 1개인 상황
  - 마이 페이지의 상,하단을 나눠서 엔드포인트를 만들지, 한번에 만들 지를 프론트랑 이야기해서 수정해야 함