### PR TITLE
Fix: 사용자 프로필 얻어오기 yml 정보 수정

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/core/oauth2/service/OAuth2Service.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/oauth2/service/OAuth2Service.java
@@ -45,8 +45,10 @@ public class OAuth2Service {
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
 
+        String url = env.getProperty(String.format("spring.social.%s.url.profile",token.getProviderName()));
+
         ResponseEntity<String> response = restTemplate.postForEntity(
-                env.getProperty(String.format("spring.social.%s.url.profile", token.getProviderName())),
+                url,
                 request,
                 String.class
         );
@@ -60,13 +62,13 @@ public class OAuth2Service {
     }
 
     public OAuth2Profile setKakaoProfile(JsonNode jsonNode) {
-        String identifier = jsonNode.get("id").textValue();
+        long identifier = jsonNode.get("id").asLong();
 
         return new OAuth2Profile("kakao_" + identifier);
     }
 
     public OAuth2Profile setGoogleProfile(JsonNode jsonNode){
-        String identifier = jsonNode.get("localId").textValue();
+        long identifier = jsonNode.get("localId").asLong();
 
         return new OAuth2Profile("google_" + identifier);
     }

--- a/mureng-api/src/test/java/net/mureng/api/oauth/OAuthServiceTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/oauth/OAuthServiceTest.java
@@ -1,6 +1,5 @@
 package net.mureng.api.oauth;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import net.mureng.api.core.jwt.dto.TokenDto;
 import net.mureng.api.core.jwt.dto.TokenProvider;
 import net.mureng.api.core.oauth2.dto.OAuth2Profile;
@@ -19,7 +18,7 @@ public class OAuthServiceTest {
 
     @Test
     public void 액세스토큰으로_사용자정보_얻어오기_테스트() {
-        String accessToken = "4pZgt2Sclf59PiM0COteqs50nMlO7EpsLKhf2go9dZoAAAF5tsxLNQ";
+        String accessToken = "Y2ijVCkF3GycaYp2ok2q3UQd0eaLsF270rCgLwo9c-sAAAF6HhFdVQ";
         TokenDto.Provider token = new TokenDto.Provider(TokenProvider.KAKAO, accessToken);
 
         OAuth2Profile profile = oAuth2Service.getProfile(token);

--- a/mureng-core/src/main/resources/application.yml
+++ b/mureng-core/src/main/resources/application.yml
@@ -21,10 +21,10 @@ spring:
       change-log: classpath:config/liquibase/master.xml
 #        enabled: false
     social:
-      kakao:
+      KAKAO:
         url:
           profile: https://kapi.kakao.com/v2/user/me
-      google:
+      GOOGLE:
         url:
           profile: https://www.googleapis.com/oauth2/v3/userinfo
 


### PR DESCRIPTION
### 문제
Enum Provider의 경우, 대문자이고, yml에 설정된 값은 소문자여서 올바른 url을 가져오지 못하는 문제가 발생
또한 identifer의 경우, String이 아닌 number에 해당해 .textValue()로 가져오지 못하는 문제가 발생

### 해결
- yml 값 수정
- long 자료형으로 매핑