### PR TITLE
Fix: 사용자 기록 탭 답변 목록 정렬 순서 변경

### DIFF
--- a/mureng-core/src/main/java/net/mureng/core/reply/repository/ReplyRepository.java
+++ b/mureng-core/src/main/java/net/mureng/core/reply/repository/ReplyRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
-    List<Reply> findAllByAuthorMemberId(Long memberId);
+    List<Reply> findAllByAuthorMemberIdOrderByRegDateDesc(Long memberId);
     List<Reply> findAllByQuestionQuestionId(Long questionId);
     Page<Reply> findAllByQuestionQuestionId(Long questionId, Pageable pageable);
 

--- a/mureng-core/src/main/java/net/mureng/core/reply/service/ReplyService.java
+++ b/mureng-core/src/main/java/net/mureng/core/reply/service/ReplyService.java
@@ -10,10 +10,12 @@ import net.mureng.core.question.service.QuestionService;
 import net.mureng.core.reply.entity.Reply;
 import net.mureng.core.reply.repository.ReplyRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
+import java.awt.print.Pageable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -115,7 +117,8 @@ public class ReplyService {
 
     @Transactional(readOnly = true)
     public List<Reply> findRepliesByMemberId(Long memberId){
-        return replyRepository.findAllByAuthorMemberId(memberId);
+
+        return replyRepository.findAllByAuthorMemberIdOrderByRegDateDesc(memberId);
     }
 
     @Transactional(readOnly = true)

--- a/mureng-core/src/test/java/net/mureng/core/reply/repository/ReplyRepositoryTest.java
+++ b/mureng-core/src/test/java/net/mureng/core/reply/repository/ReplyRepositoryTest.java
@@ -38,18 +38,18 @@ public class ReplyRepositoryTest {
     private static final Long REPLY_ID = 1L;
 
     @Test
-    public void 멤버_답변_목록_조회(){
-        List<Reply> replyList = replyRepository.findAllByAuthorMemberId(MEMBER_ID);
+    public void 멤버_답변_목록_조회_내림차순(){
+        List<Reply> replyList = replyRepository.findAllByAuthorMemberIdOrderByRegDateDesc(MEMBER_ID);
 
         assertEquals(2, replyList.size());
 
         assertEquals(MEMBER_ID, replyList.get(0).getAuthor().getMemberId());
-        assertEquals("yellow", replyList.get(0).getContent());
-        assertEquals("yellow image", replyList.get(0).getImage());
+        assertEquals("so cute", replyList.get(0).getContent());
+        assertEquals("cat image", replyList.get(0).getImage());
 
         assertEquals(MEMBER_ID, replyList.get(1).getAuthor().getMemberId());
-        assertEquals("so cute", replyList.get(1).getContent());
-        assertEquals("cat image", replyList.get(1).getImage());
+        assertEquals("yellow", replyList.get(1).getContent());
+        assertEquals("yellow image", replyList.get(1).getImage());
     }
 
     @Test


### PR DESCRIPTION
사용자 기록 탭 답변 목록이 현재 정렬이 오름차순인데, 내림차순으로 변경