### PR TITLE
feat: 회원가입시 닉네임 검증 로직 추가

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/core/util/NicknameNormalizer.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/util/NicknameNormalizer.java
@@ -1,0 +1,48 @@
+package net.mureng.api.core.util;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+/**
+ * 닉네임 정규화 도구 <br>
+ * 최대 12자로 규정하되, 한글의 경우 2자로 계산한다. <br>
+ * 그 이상은 잘라낸다.
+ */
+public class NicknameNormalizer {
+    private static final int MAXIMUM_LENGTH = 12;
+
+    private NicknameNormalizer() { }
+
+    public static String normalize(@Nullable String nickname) {
+        if (! StringUtils.hasText(nickname)) {
+            return nickname;
+        }
+
+        int remainLength = MAXIMUM_LENGTH;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < nickname.length(); i++) {
+            char ch = nickname.charAt(i);
+            if (isKorean(ch)) {
+                if (remainLength <= 1) {
+                    return sb.toString();
+                }
+                sb.append(ch);
+                remainLength -= 2;
+
+            } else {
+                sb.append(ch);
+                remainLength -= 1;
+                if (remainLength <= 0) {
+                    break;
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static boolean isKorean(char value) {
+        return ( 0xAC00 <= value && value <= 0xD7A3 ) || ( 0x3131 <= value && value <= 0x318E );
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/core/validation/KorEngOnlyValidator.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/validation/KorEngOnlyValidator.java
@@ -1,0 +1,17 @@
+package net.mureng.api.core.validation;
+
+import net.mureng.api.core.validation.annotation.KorEngOnly;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+/**
+ * 한글, 숫자, 영어만 허용한다. 한글의 경우 자음, 모음 만 사용하는건 허용 안함
+ */
+public class KorEngOnlyValidator implements ConstraintValidator<KorEngOnly, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+       return Pattern.matches("^[가-힣0-9a-zA-Z]*$", value);
+    }
+}

--- a/mureng-api/src/main/java/net/mureng/api/core/validation/annotation/KorEngOnly.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/validation/annotation/KorEngOnly.java
@@ -1,0 +1,24 @@
+package net.mureng.api.core.validation.annotation;
+
+import net.mureng.api.core.validation.KorEngOnlyValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = KorEngOnlyValidator.class)
+@Documented
+public @interface KorEngOnly {
+    String message() default "한글, 숫자, 영어만 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberDto.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import net.mureng.api.core.util.NicknameNormalizer;
+import net.mureng.api.core.validation.annotation.KorEngOnly;
 import net.mureng.core.member.entity.MemberSetting;
 
 import javax.validation.constraints.Email;
@@ -29,6 +31,7 @@ public class MemberDto {
     @JsonProperty(index = PropertyDisplayOrder.EMAIL)
     private String email;
 
+    @KorEngOnly
     @NotBlank
     @ApiModelProperty(value = "닉네임", required = true, position = PropertyDisplayOrder.NICKNAME)
     @JsonProperty(index = PropertyDisplayOrder.NICKNAME)
@@ -37,6 +40,10 @@ public class MemberDto {
     @ApiModelProperty(value = "프로필 이미지 경로", position = PropertyDisplayOrder.IMAGE)
     @JsonProperty(index = PropertyDisplayOrder.IMAGE)
     private String image;
+
+    public void setNickname(String nickname) {
+        this.nickname = NicknameNormalizer.normalize(nickname);
+    }
 
     @SuperBuilder
     @Getter @Setter

--- a/mureng-api/src/test/java/net/mureng/api/core/util/NicknameNormalizerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/core/util/NicknameNormalizerTest.java
@@ -1,0 +1,19 @@
+package net.mureng.api.core.util;
+
+import net.mureng.api.member.dto.MemberDto;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NicknameNormalizerTest {
+    @Test
+    void 닉네임_정규화_테스트() {
+        assertEquals("최대여섯글자", NicknameNormalizer.normalize("최대여섯글자"));
+        assertEquals("최대여섯글자", NicknameNormalizer.normalize("최대여섯글자초과"));
+        assertEquals("MaximumNickn", NicknameNormalizer.normalize("MaximumNickn"));
+        assertEquals("MaximumNickn", NicknameNormalizer.normalize("MaximumNickname"));
+        assertEquals("최대여섯Nick", NicknameNormalizer.normalize("최대여섯Nickname"));
+        assertEquals("최대여섯Na12", NicknameNormalizer.normalize("최대여섯Na123456"));
+        assertEquals("최N대i여c섯k", NicknameNormalizer.normalize("최N대i여c섯k글n자ame"));
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/core/validation/AbstractValidatorTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/core/validation/AbstractValidatorTest.java
@@ -1,4 +1,4 @@
-package net.mureng.api.core.component;
+package net.mureng.api.core.validation;
 
 import org.junit.jupiter.api.BeforeEach;
 

--- a/mureng-api/src/test/java/net/mureng/api/core/validation/DateStringValidatorTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/core/validation/DateStringValidatorTest.java
@@ -1,8 +1,7 @@
-package net.mureng.api.core.component;
+package net.mureng.api.core.validation;
 
 
 import net.mureng.api.core.validation.annotation.DateFormat;
-import net.mureng.api.core.validation.DateStringValidator;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;

--- a/mureng-api/src/test/java/net/mureng/api/core/validation/KorEngOnlyValidatorTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/core/validation/KorEngOnlyValidatorTest.java
@@ -1,0 +1,51 @@
+package net.mureng.api.core.validation;
+
+import net.mureng.api.core.validation.annotation.KorEngOnly;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KorEngOnlyValidatorTest extends AbstractValidatorTest {
+    @Test
+    public void 한글영어문자열_검증_단순_테스트() {
+        KorEngOnlyValidator validator = new KorEngOnlyValidator();
+        assertTrue(validator.isValid("한글만된다", null));
+        assertTrue(validator.isValid("canbeenglish", null));
+        assertTrue(validator.isValid("Canbeboth둘다된다", null));
+        assertTrue(validator.isValid("한글english1234", null));
+        assertFalse(validator.isValid("얘는안된다;;", null));
+        assertFalse(validator.isValid("notthistoo~.~", null));
+        assertFalse(validator.isValid("해보니까 공백넣는 것도 안됨", null));
+    }
+
+    @Test
+    public void 한글영어문자열_검증_심화_테스트() {
+        SimpleDto simpleDto = new SimpleDto("한글english1234");
+        Set<ConstraintViolation<SimpleDto>> violations = validator.validate(simpleDto);
+        assertTrue(violations.isEmpty());
+
+        simpleDto = new SimpleDto("얘는 안된다;;");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("not this too ~.~");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+    }
+
+    private static class SimpleDto {
+        SimpleDto(String value) {
+            this.value = value;
+        }
+
+        @KorEngOnly
+        private final String value;
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/mureng-api/src/test/java/net/mureng/api/core/validation/TimeStringValidatorTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/core/validation/TimeStringValidatorTest.java
@@ -1,8 +1,7 @@
-package net.mureng.api.core.component;
+package net.mureng.api.core.validation;
 
 
 import net.mureng.api.core.validation.annotation.TimeFormat;
-import net.mureng.api.core.validation.TimeStringValidator;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;

--- a/mureng-api/src/test/java/net/mureng/api/question/component/QuestionDtoValidationTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/question/component/QuestionDtoValidationTest.java
@@ -1,9 +1,7 @@
 package net.mureng.api.question.component;
 
 
-import net.mureng.api.core.component.AbstractValidatorTest;
-import net.mureng.api.core.validation.TimeStringValidator;
-import net.mureng.api.core.validation.annotation.TimeFormat;
+import net.mureng.api.core.validation.AbstractValidatorTest;
 import net.mureng.api.question.dto.QuestionDto;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
- 한글, 영어, 숫자 외 문자 입력 시 에러 발생
- 12자 넘어가면 잘려서 입력 (단, 한글은 하나에 2자로 취급)