### PR TITLE
test: 통합 테스트 작성

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/dto/MemberAchievementDto.java
@@ -28,7 +28,7 @@ public class MemberAchievementDto {
     private boolean requesterProfile;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @ApiModelProperty(value = "사용자가 획득한 뱃지 번호")
+    @ApiModelProperty(value = "사용자가 획득한 뱃지 번호") // TODO 사용자 뱃지 목록이 있는데 왜 필요한지 ??
     @JsonProperty(index = PropertyDisplayOrder.ACCOMPLISHED_BADGE)
     private Long accomplishedBadge;
 

--- a/mureng-api/src/main/java/net/mureng/api/member/service/MemberBadgeService.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/service/MemberBadgeService.java
@@ -21,7 +21,7 @@ public class MemberBadgeService {
     }
 
     @Transactional
-    public boolean updateBadgeAccomplished(Long memberId, Long badgeId){
+    public boolean updateBadgeAccomplishedChecked(Long memberId, Long badgeId){
         BadgeAccomplishedPK pk = BadgeAccomplishedPK.builder().memberId(memberId).badgeId(badgeId).build();
         BadgeAccomplished badgeAccomplished = badgeAccomplishedRepository.findById(pk).orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 리소스에 대한 요청입니다."));
         badgeAccomplished.setIsChecked(true);

--- a/mureng-api/src/main/java/net/mureng/api/member/web/MemberAchievementController.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/web/MemberAchievementController.java
@@ -40,7 +40,7 @@ public class MemberAchievementController {
         Member profileMember = memberService.findById(memberId);
 
         return ResponseEntity.ok(ApiResult.ok(
-                memberAchievementMapper.toDto(profileMember, badges, member, badgeAccomplishedService.isAlreadyCheckedCelebrityMureng(memberId))
+                memberAchievementMapper.toDto(profileMember, badges, member, badgeAccomplishedService.isAlreadyCheckedCelebrityMureng(memberId)) // TODO 이게 여기 오는게 맞는걸까?
         ));
     }
 }

--- a/mureng-api/src/main/java/net/mureng/api/member/web/MemberBadgeController.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/web/MemberBadgeController.java
@@ -26,7 +26,7 @@ public class MemberBadgeController {
     public ResponseEntity<ApiResult<BadgeAccomplishedCheckDto>> updateBadgeAccomplished(@CurrentUser Member member, @PathVariable Long badgeId) {
         return ResponseEntity.ok(
                 ApiResult.ok(
-                        new BadgeAccomplishedCheckDto(memberBadgeService.updateBadgeAccomplished(member.getMemberId(), badgeId))
+                        new BadgeAccomplishedCheckDto(memberBadgeService.updateBadgeAccomplishedChecked(member.getMemberId(), badgeId))
                 )
         );
     }

--- a/mureng-api/src/test/java/net/mureng/api/config/WithMockMurengUserSecurityContextFactory.java
+++ b/mureng-api/src/test/java/net/mureng/api/config/WithMockMurengUserSecurityContextFactory.java
@@ -20,11 +20,11 @@ public class WithMockMurengUserSecurityContextFactory implements WithSecurityCon
         UserDetailsImpl principal =
                 new UserDetailsImpl(Member.builder()
                         .memberId(1L)
-                        .identifier("123")
+                        .identifier("identity")
                         .email("test@gmail.com")
                         .isActive(true)
-                        .nickname("Test")
-                        .image("tester-image-path")
+                        .nickname("테스트유저")
+                        .image("/reply/1621586761110.png")
                         .regDate(LocalDateTime.of(2020, 10, 14, 17, 11, 9))
                         .modDate(LocalDateTime.of(2020, 10, 14, 17, 11, 10))
                         .build());

--- a/mureng-api/src/test/java/net/mureng/api/member/web/MemberAchievementControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/web/MemberAchievementControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -26,38 +27,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MemberAchievementControllerTest extends AbstractControllerTest {
-
-    @MockBean
-    private MemberBadgeService memberBadgeService;
-
-    @MockBean
-    private MemberService memberService;
-
-    @MockBean
-    private BadgeAccomplishedService badgeAccomplishedService;
-
     private static final long MEMBER_ID = 1L;
-    private static final List<BadgeAccomplished> badgeAccomplisheds = Arrays.asList(EntityCreator.createBadgeAccomplishedEntity(), EntityCreator.createBadgeAccomplishedEntity());
-
-    private List<Badge> badges = Arrays.asList(EntityCreator.createBadgeEntity(), EntityCreator.createBadgeEntity());
-    private Member member = EntityCreator.createMemberEntity();
 
     @Test
     @WithMockMurengUser
     public void 사용자_성과_가져오기_테스트() throws Exception{
-        given(memberBadgeService.getMemberBadges(eq(MEMBER_ID))).willReturn(badgeAccomplisheds);
-        given(memberService.findById(eq(MEMBER_ID))).willReturn(member);
-        given(badgeAccomplishedService.isAlreadyCheckedCelebrityMureng(any())).willReturn(true);
-
         mockMvc.perform(
-                get("/api/member/{memberId}/achievement", 1)
+                get("/api/member/{memberId}/achievement", MEMBER_ID)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.member.memberId").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.member.email").value("test@gmail.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.badges[0].name").value("Badge Test"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.badges[0].content").value("Badge Test Content"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.badges", hasSize(2)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.requesterProfile").value("true"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.accomplishedBadge").value(BadgeAccomplishedServiceImpl.CelebrityMureng.id))
                 .andDo(print());

--- a/mureng-api/src/test/java/net/mureng/api/member/web/MemberBadgeControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/web/MemberBadgeControllerTest.java
@@ -14,14 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MemberBadgeControllerTest extends AbstractControllerTest {
-    @MockBean
-    private MemberBadgeService memberBadgeService;
-
     @Test
     @WithMockMurengUser
     public void 사용자_뱃지_획득_확인_테스트() throws Exception {
-        given(memberBadgeService.updateBadgeAccomplished(any(), any())).willReturn(true);
-
         mockMvc.perform(
                 put("/api/member/me/check/badge/{badgeId}",  1)
         ).andExpect(status().isOk())

--- a/mureng-api/src/test/java/net/mureng/api/member/web/MemberControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/web/MemberControllerTest.java
@@ -8,9 +8,11 @@ import net.mureng.core.member.entity.MemberAttendance;
 import net.mureng.core.member.entity.MemberSetting;
 import net.mureng.api.web.AbstractControllerTest;
 import net.mureng.core.member.service.MemberService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -26,40 +28,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends AbstractControllerTest {
-    private final Member newMember = Member.builder()
-                                            .memberId(1L)
-                                            .email("example@email.com")
-                                            .identifier("user-identifier")
-                                            .image("image-path")
-                                            .nickname("최대여섯글자")
-                                            .memberAttendance(MemberAttendance.builder()
-                                                    .lastAttendanceDate(LocalDate.parse("2020-10-14"))
-                                                    .attendanceCount(0)
-                                                    .build())
-                                            .memberSetting(MemberSetting.builder()
-                                                    .isLikePushActive(true)
-                                                    .isDailyPushActive(false)
-                                                    .build())
-                                            .murengCookies(Set.of())
-                                            .build();
-
-    private final String newMemberJsonString = "{" +
-                                                "  \"email\": \"example@email.com\",\n" +
-                                                "  \"identifier\": \"user-identifier\",\n" +
-                                                "  \"image\": \"image-path\",\n" +
-                                                "  \"nickname\": \"최대여섯글자\",\n" +
-                                                "  \"pushActive\": true\n" +
-                                                "}";
-
-    @MockBean
-    MemberService memberService;
-
-    @MockBean
-    MemberSignupService memberSignupService;
-
     @Test
     public void 사용자_회원가입_테스트() throws Exception {
-        given(memberSignupService.signup(any())).willReturn(newMember);
+        String newMemberJsonString = "{" +
+                "  \"email\": \"example@email.com\",\n" +
+                "  \"identifier\": \"user-identifier\",\n" +
+                "  \"image\": \"image-path\",\n" +
+                "  \"nickname\": \"최대여섯글자\",\n" +
+                "  \"pushActive\": true\n" +
+                "}";
 
         mockMvc.perform(
                 post("/api/member/signup")
@@ -67,21 +44,46 @@ class MemberControllerTest extends AbstractControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.murengCount").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("최대여섯글자"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(false));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
+    }
+
+    @Test
+    public void 사용자_회원가입_닉네임초과_테스트() throws Exception {
+        String newMemberJsonStringOverNickname = "{" +
+                "  \"email\": \"example@email.com\",\n" +
+                "  \"identifier\": \"user-identifier\",\n" +
+                "  \"image\": \"image-path\",\n" +
+                "  \"nickname\": \"최대여섯글자초과\",\n" +
+                "  \"pushActive\": true\n" +
+                "}";
+
+        mockMvc.perform(
+                post("/api/member/signup")
+                        .content(newMemberJsonStringOverNickname)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(4L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.murengCount").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("최대여섯글자"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
     }
 
     @Test
     public void 사용자_닉네임중복체크_테스트() throws Exception {
-        given(memberService.isNicknameDuplicated(any())).willReturn(false);
-
         mockMvc.perform(
                 get("/api/member/nickname-exists/테스트이름")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -92,10 +94,8 @@ class MemberControllerTest extends AbstractControllerTest {
 
     @Test
     public void 사용자_닉네임중복체크_테스트2() throws Exception {
-        given(memberService.isNicknameDuplicated(any())).willReturn(true);
-
         mockMvc.perform(
-                get("/api/member/nickname-exists/테스트이름")
+                get("/api/member/nickname-exists/테스트유저")
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
@@ -105,11 +105,6 @@ class MemberControllerTest extends AbstractControllerTest {
     @Test
     @WithMockMurengUser
     public void 사용자_정보수정_테스트() throws Exception {
-        ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
-        newMember.setNickname("변경된닉네임");
-        newMember.setImage("modified-image-path");
-        given(memberService.saveMember(memberArgumentCaptor.capture())).willReturn(newMember);
-
         mockMvc.perform(
                 patch("/api/member/modify")
                         .content("{\"nickname\": \"변경된닉네임\", \"image\": \"modified-image-path\"}")
@@ -117,25 +112,19 @@ class MemberControllerTest extends AbstractControllerTest {
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("modified-image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.murengCount").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(false));
-        assertEquals("변경된닉네임", memberArgumentCaptor.getValue().getNickname());
-        assertEquals("modified-image-path", memberArgumentCaptor.getValue().getImage());
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
     }
 
     @Test
     @WithMockMurengUser
     public void 사용자_정보_닉네임수정_테스트() throws Exception {
-        ArgumentCaptor<Member> memberArgumentCaptor = ArgumentCaptor.forClass(Member.class);
-        newMember.setNickname("변경된닉네임");
-        given(memberService.saveMember(memberArgumentCaptor.capture())).willReturn(newMember);
-
         mockMvc.perform(
                 patch("/api/member/modify")
                         .content("{\"nickname\": \"변경된닉네임\"}")
@@ -143,16 +132,34 @@ class MemberControllerTest extends AbstractControllerTest {
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("example@email.com"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("user-identifier"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.murengCount").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(false));
-        assertEquals("변경된닉네임", memberArgumentCaptor.getValue().getNickname());
-        assertEquals("tester-image-path", memberArgumentCaptor.getValue().getImage());
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 사용자_정보_닉네임수정_닉네임초과_테스트() throws Exception {
+        mockMvc.perform(
+                patch("/api/member/modify")
+                        .content("{\"nickname\": \"변경된닉네임초과\"}")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("test@gmail.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.identifier").value("identity"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("/reply/1621586761110.png"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lastAttendanceDate").value("2020-10-14"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.murengCount").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("변경된닉네임"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.likePushActive").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberSetting.dailyPushActive").value(true));
     }
 
     @Test
@@ -164,23 +171,32 @@ class MemberControllerTest extends AbstractControllerTest {
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
                 .andDo(print());
     }
 
     @Test
     @WithMockMurengUser
     public void 사용자_프로필_가져오기_테스트() throws Exception {
-        given(memberService.findById(eq(1L))).willReturn(EntityCreator.createMemberEntity());
-
         mockMvc.perform(
                 get("/api/member/{memberId}", 1)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("테스트유저"))
                 .andDo(print());
 
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 사용자_탈퇴_테스트() throws Exception {
+        mockMvc.perform(
+                delete("/api/member/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andDo(print());
     }
 }

--- a/mureng-api/src/test/java/net/mureng/api/member/web/MemberReplyControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/web/MemberReplyControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,36 +22,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberReplyControllerTest extends AbstractControllerTest {
-    @MockBean
-    ReplyService replyService;
-
     @Test
     @WithMockMurengUser
     public void 사용자_답변_목록_조회_테스트() throws Exception {
-        Member member = EntityCreator.createMemberEntity();
-        List<Reply> replies = Arrays.asList(EntityCreator.createReplyEntity(), EntityCreator.createReplyEntity());
-
-        given(replyService.findRepliesByMemberId(eq(1L))).willReturn(replies);
-
         mockMvc.perform(
                 get("/api/member/{memberId}/replies", 1)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("this is test reply 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("this is test reply 1"))
                 .andDo(print());
     }
 
     @Test
     @WithMockMurengUser
     public void 사용자_오늘_답변했는지_테스트() throws Exception {
-        given(replyService.isAlreadyRepliedToday(eq(1L))).willReturn(true);
-
         mockMvc.perform(
                 get("/api/member/check-replied-today")
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replied").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replied").value(false))
                 .andDo(print());
     }
 }

--- a/mureng-api/src/test/java/net/mureng/api/question/web/TodayQuestionControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/question/web/TodayQuestionControllerTest.java
@@ -25,51 +25,45 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class TodayQuestionControllerTest extends AbstractControllerTest {
     @MockBean
-    private TodayQuestionService todayQuestionService;
-
-    @MockBean
     private TodayQuestionSelectionService todayQuestionSelectionService;
-
-    private final Question question = Question.builder()
-            .questionId(1L)
-            .author(Member.builder().murengCookies(Set.of()).build())
-            .category("카테고리")
-            .content("This is english content.")
-            .koContent("이것은 한글 내용입니다.")
-            .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
-            .wordHints(new HashSet<>(List.of(
-                    WordHint.builder()
-                            .hintId(1L)
-                            .question(Question.builder().build())
-                            .word("apple")
-                            .meaning("사과")
-                            .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
-                            .build()
-            )))
-            .build();
 
     @Test
     @WithMockMurengUser
     public void 오늘의_질문_조회_테스트() throws Exception {
-        given(todayQuestionService.getTodayQuestionByMemberId(eq(1L))).willReturn(question);
-
         mockMvc.perform(
                 get("/api/today-question")
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.questionId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.category").value("카테고리"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("This is english content."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.koContent").value("이것은 한글 내용입니다."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.category").value("테스트"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.koContent").value("이것은 테스트 질문입니다."))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.wordHints[0].hintId").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.wordHints[0].word").value("apple"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.wordHints[0].meaning").value("사과"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.wordHints[0].word").value("meaning 1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.wordHints[0].meaning").value("의미 1"));
     }
 
     @Test
     @WithMockMurengUser
     public void 오늘의_질문_새로고침_테스트() throws Exception {
+        Question question = Question.builder()
+                .questionId(1L)
+                .author(Member.builder().murengCookies(Set.of()).build())
+                .category("카테고리")
+                .content("This is english content.")
+                .koContent("이것은 한글 내용입니다.")
+                .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
+                .wordHints(new HashSet<>(List.of(
+                        WordHint.builder()
+                                .hintId(1L)
+                                .question(Question.builder().build())
+                                .word("apple")
+                                .meaning("사과")
+                                .regDate(LocalDateTime.parse("2020-10-14T11:00:00"))
+                                .build()
+                )))
+                .build();
         given(todayQuestionSelectionService.reselectTodayQuestion(any())).willReturn(question);
 
         mockMvc.perform(

--- a/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyControllerTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -28,100 +29,108 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ReplyControllerTest extends AbstractControllerTest {
-
-    @MockBean
-    private ReplyService replyService;
-
-    @MockBean
-    private ReplyPaginationService replyPaginationService;
-
-    @MockBean
-    private BadgeAccomplishedService badgeAccomplishedService;
-
-    private final String newReplyJsonString = "{\"content\": \"Test Reply\",\n" +
-            "  \"image\": \"image-path\" ,\n" +
-            "  \"questionId\" : 1 }";
-
-    private final String updateReplyJsonString = "{\"content\": \"Test Reply\",\n" +
-            "  \"image\": \"image-path\" }";
-
-    private static final Long MEMBER_ID = 1L;
-    private static final Long QUESTION_ID = 1L;
     private static final Long REPLY_ID = 1L;
 
     @Test
     @WithMockMurengUser
-    public void 답변_조회_테스트() throws Exception {
-        Reply reply1 = EntityCreator.createReplyEntity();
-        reply1.setContent("content1");
-        Reply reply2 = EntityCreator.createReplyEntity();
-        reply2.setContent("content2");
-        reply2.setReplyLikes(new HashSet<>());
-        List<Reply> replies = Arrays.asList(reply1, reply2);
+    public void 답변_인기순_조회_테스트() throws Exception {
         int page = 0;
-        int size = 10;
-
-        given(replyPaginationService.findReplies(eq(new ApiPageRequest(page, size, ApiPageRequest.PageSort.POPULAR))))
-                .willReturn(new PageImpl<>(replies, PageRequest.of(page, size), 2));
-
+        int size = 2;
         mockMvc.perform(
-                get("/api/reply")
+                get("/api/reply?page={page}&size={size}&sort=popular", page, size)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("content1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyId").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("this is test reply 1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyLikeCount").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].question.content").value("This is english content."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].author.nickname").value("Test"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("content2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].question.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].author.nickname").value("테스트유저"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyId").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("this is test reply 3"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyLikeCount").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].question.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].author.nickname").value("테스트유저2"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_최신순_조회_테스트() throws Exception {
+        int page = 0;
+        int size = 2;
+        mockMvc.perform(
+                get("/api/reply?page={page}&size={size}&sort=newest", page, size)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyId").value(6))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("this is test reply 6"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].replyLikeCount").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].question.content").value("This is user-defined question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].author.nickname").value("테스트유저3"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyId").value(5))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("this is test reply 5"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].replyLikeCount").value(0))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].question.content").value("This is english content."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].author.nickname").value("Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].question.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].author.nickname").value("테스트유저3"))
                 .andDo(print());
     }
 
     @Test
     @WithMockMurengUser
     public void 답변_상세_조회_테스트() throws Exception {
-        given(replyService.findById(eq(REPLY_ID))).willReturn(EntityCreator.createReplyEntity());
-
         mockMvc.perform(
-                get("/api/reply/{replyId}", 1)
+                get("/api/reply/{replyId}", REPLY_ID)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("Test Reply"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("this is test reply 1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyLikeCount").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.question.content").value("This is english content."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.author.nickname").value("Test"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.question.content").value("This is test question."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.author.nickname").value("테스트유저"))
                 .andDo(print());
     }
 
     @Test
     @WithMockMurengUser
     public void 답변_등록_테스트() throws Exception {
-        given(replyService.create(any())).willReturn(EntityCreator.createReplyEntity());
-        given(badgeAccomplishedService.createMureng3Days(any())).willReturn(false);
-        given(badgeAccomplishedService.createMurengSet(any())).willReturn(true);
-
+        String newReplyJsonString = "{\"content\": \"Test Reply\",\n" +
+                "  \"image\": \"image-path\" ,\n" +
+                "  \"questionId\" : 3 }";
         mockMvc.perform(
                 post("/api/reply")
                 .content(newReplyJsonString)
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyId").value(1L))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("Test Reply"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.accomplishedBadge").value(BadgeAccomplishedServiceImpl.MurengSet.id))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.accomplishedBadge").value(0L))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 이미_등록한_답변_오류_테스트() throws Exception {
+        String alreadyRepliedQuestionJsonString = "{\"content\": \"Test Reply\",\n" +
+                "  \"image\": \"image-path\" ,\n" +
+                "  \"questionId\" : 1 }";
+        mockMvc.perform(
+                post("/api/reply")
+                        .content(alreadyRepliedQuestionJsonString)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest())
                 .andDo(print());
     }
 
     @Test
     @WithMockMurengUser
     public void 답변_수정_테스트() throws Exception {
-        given(replyService.update(any())).willReturn(EntityCreator.createReplyEntity());
-
+        String updateReplyJsonString = "{\"content\": \"Test Reply\",\n" +
+                "  \"image\": \"image-path\" }";
         mockMvc.perform(
                 put("/api/reply/1")
                         .content(updateReplyJsonString)
@@ -131,6 +140,18 @@ public class ReplyControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyId").value(1L))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("Test Reply"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value("image-path"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_삭제_테스트() throws Exception {
+        mockMvc.perform(
+                delete("/api/reply/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.deleted").value(true))
                 .andDo(print());
     }
 }

--- a/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyLikesControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/reply/web/ReplyLikesControllerTest.java
@@ -12,29 +12,56 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ReplyLikesControllerTest extends AbstractControllerTest {
-    @MockBean
-    private ReplyLikesService replyLikesService;
-
-    private static final long REPLY_ID = 1L;
 
     @Test
     @WithMockMurengUser
     public void 답변_좋아요_등록_테스트() throws Exception {
-        given(replyLikesService.postReplyLikes(any(), eq(REPLY_ID))).willReturn(EntityCreator.createReplyLikesEntity());
-
         mockMvc.perform(
-                post("/api/reply/{replyId}/reply-likes", 1)
+                post("/api/reply/{replyId}/reply-likes", 2)
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.replyId").value(2L))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.likes").value(true))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_이미넣은_좋아요_등록_오류_테스트() throws Exception {
+        mockMvc.perform(
+                post("/api/reply/{replyId}/reply-likes", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_좋아요_삭제_테스트() throws Exception {
+        mockMvc.perform(
+                delete("/api/reply/{replyId}/reply-likes", 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.deleted").value(true))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockMurengUser
+    public void 답변_존재하지않는_좋아요_삭제_오류_테스트() throws Exception {
+        mockMvc.perform(
+                delete("/api/reply/{replyId}/reply-likes", 2)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest())
                 .andDo(print());
     }
 }

--- a/mureng-api/src/test/java/net/mureng/api/todayexpression/web/UsefulExpressionControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/todayexpression/web/UsefulExpressionControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -22,32 +23,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class UsefulExpressionControllerTest extends AbstractControllerTest {
 
-    @MockBean
-    private UsefulExpressionService usefulExpressionService;
-
     @Test
     @WithMockMurengUser
     public void 오늘의_표현_가져오기_테스트() throws Exception {
-        UsefulExpression usefulExpression1 = EntityCreator.createUsefulExpressionEntity();
-        UsefulExpression usefulExpression2 = EntityCreator.createUsefulExpressionEntity();
-        List<UsefulExpression> usefulExpressionList = Arrays.asList(usefulExpression1, usefulExpression2);
-
-        int page = 0;
-        int size = 2;
-
-        given(usefulExpressionService.getTodayExpressions()).willReturn(usefulExpressionList);
-
         mockMvc.perform(
                 get("/api/today-expression")
                         .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expression").value("test"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].meaning").value("테스트"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expressionExample").value("test driven development"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expressionExampleMeaning").value("테스트 주도 개발"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].expression").value("test"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].meaning").value("테스트"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data", hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expression").value("I'm sure that ~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].meaning").value("~라는 것을 확신해"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expressionExample").value("I'm sure that I will achieve my goal."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].expressionExampleMeaning").value("난 내 목표를 달성할 거라고 확신해."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].expId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].expression").value("I'm happy to ~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].meaning").value("~해서 기뻐"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].expressionExample").value("I'm happy to see you again."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].expressionExampleMeaning").value("널 다시 보게 돼서 기뻐."))
                 .andDo(print());
     }
 }

--- a/mureng-api/src/test/java/net/mureng/api/web/AbstractControllerTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/web/AbstractControllerTest.java
@@ -3,11 +3,15 @@ package net.mureng.api.web;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+@Transactional
+@Sql("classpath:/sql/integration.sql")
 @SpringBootTest
 @AutoConfigureMockMvc
 public abstract class AbstractControllerTest {

--- a/mureng-core/src/test/resources/sql/integration.sql
+++ b/mureng-core/src/test/resources/sql/integration.sql
@@ -1,4 +1,38 @@
-INSERT INTO member (member_id, email, identifier, image, is_active, attendance_count, last_attendance_date, is_daily_push_active, mod_date, nickname, reg_date, is_like_push_active) VALUES (1, 'test@email.com', 'identity', '/reply/1621586761110.png', true, 0, '2021-05-13', false, '2021-07-08 11:30:00.184937', '테스트유저', '2021-05-13 01:31:33.400876', true);
+INSERT INTO member (member_id, email, identifier, image, is_active, attendance_count, last_attendance_date, is_daily_push_active, mod_date, nickname, reg_date, is_like_push_active) VALUES (1, 'test@gmail.com', 'identity', '/reply/1621586761110.png', true, 0, '2021-05-13', true, '2020-10-14 17:11:09.400891', '테스트유저', '2020-10-14 17:11:09.400876', true);
+INSERT INTO member (member_id, email, identifier, image, is_active, attendance_count, last_attendance_date, is_daily_push_active, mod_date, nickname, reg_date, is_like_push_active) VALUES (2, 'test2@email.com', 'identity2', null, true, 0, '2020-12-05', true, '2021-05-13 02:59:27.582760', '테스트유저2', '2021-05-13 02:59:27.582760', true);
+INSERT INTO member (member_id, email, identifier, image, is_active, attendance_count, last_attendance_date, is_daily_push_active, mod_date, nickname, reg_date, is_like_push_active) VALUES (3, 'test3@email.com', 'identity3', '/reply/1621586761110.png', true, 0, '2021-05-13', false, '2021-07-08 11:30:00.184937', '테스트유저3', '2021-05-13 01:31:33.400876', true);
+
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (1, '테스트', 'This is test question.', '이것은 테스트 질문입니다.', '2021-05-13 02:54:36', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (2, '테스트2', 'This is test question2.', '이것은 테스트 질문2입니다.', '2021-05-18 13:47:07', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (3, '테스트3', 'This is user-defined question.', '이것은 사용자가 등록한 질문입니다.', '2021-05-18 13:47:08', 1);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (4, '테스트', 'This is test question3.', '이것은 테스트 질문3입니다.', '2021-05-18 13:47:09', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (5, '테스트', 'This is test question4.', '이것은 테스트 질문4입니다.', '2021-05-18 13:47:10', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (6, '테스트', 'This is test question5.', '이것은 테스트 질문5입니다.', '2021-05-18 13:47:11', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (7, '테스트', 'This is test question6.', '이것은 테스트 질문6입니다.', '2021-05-18 13:47:12', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (8, '테스트', 'This is test question7.', '이것은 테스트 질문7입니다.', '2021-05-18 13:47:13', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (9, '테스트', 'This is test question8.', '이것은 테스트 질문8입니다.', '2021-05-18 13:47:14', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (10, '테스트', 'This is test question9.', '이것은 테스트 질문9입니다.', '2021-05-18 13:47:15', null);
+INSERT INTO question (question_id, category, content, ko_content, reg_date, member_id) VALUES (11, '테스트', 'This is test question10.', '이것은 테스트 질문10입니다.', '2021-05-18 13:47:16', null);
+
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (1, 'this is test reply 1', false, '/reply/1621586761110.png', '2021-05-18 12:48:01', '2021-05-18 12:49:01', true, 1, 1);
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (2, 'this is test reply 2', false, '/reply/1621586761110.png', '2021-05-18 12:48:02', '2021-05-18 12:49:02', true, 1, 2);
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (3, 'this is test reply 3', false, '/reply/1621586761110.png', '2021-05-18 12:48:03', '2021-05-18 12:49:03', true, 2, 1);
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (4, 'this is test reply 4', false, '/reply/1621586761110.png', '2021-05-18 12:48:04', '2021-05-18 12:49:04', true, 2, 2);
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (5, 'this is test reply 5', false, '/reply/1621586761110.png', '2021-05-18 12:48:05', '2021-05-18 12:49:05', true, 3, 1);
+INSERT INTO reply (reply_id, content, deleted, image, mod_date, reg_date, visible, member_id, question_id) VALUES (6, 'this is test reply 6', false, '/reply/1621586761110.png', '2021-05-18 12:48:06', '2021-05-18 12:49:06', true, 3, 3);
+
+INSERT INTO reply_likes (member_id, reply_id, reg_date) VALUES (1, 1, '2021-07-01 18:58:26');
+INSERT INTO reply_likes (member_id, reply_id, reg_date) VALUES (2, 1, '2021-07-03 11:42:26');
+INSERT INTO reply_likes (member_id, reply_id, reg_date) VALUES (1, 3, '2021-07-03 14:58:12');
+
+INSERT INTO word_hint (hint_id, meaning, reg_date, word, question_id) VALUES (1, '의미 1', '2021-05-14 01:31:18', 'meaning 1', 1);
+INSERT INTO word_hint (hint_id, meaning, reg_date, word, question_id) VALUES (2, '의미 2', '2021-05-14 01:31:18', 'meaning 2', 2);
+INSERT INTO word_hint (hint_id, meaning, reg_date, word, question_id) VALUES (3, '의미 3', '2021-05-14 01:31:18', 'meaning 3', 3);
+INSERT INTO word_hint (hint_id, meaning, reg_date, word, question_id) VALUES (4, '의미 4', '2021-05-14 01:31:18', 'meaning 4', 4);
+
+INSERT INTO today_question (member_id, mod_date, reg_date, question_id) VALUES (1, '2021-05-13 02:55:27', '2021-05-13 02:55:29', 1);
+INSERT INTO today_question (member_id, mod_date, reg_date, question_id) VALUES (2, '2021-05-13 02:59:27', '2021-05-13 02:59:27', 2);
+INSERT INTO today_question (member_id, mod_date, reg_date, question_id) VALUES (3, '2021-05-13 02:59:28', '2021-05-13 02:59:28', 3);
 
 INSERT INTO useful_expression (exp_id, expression, expression_example, expression_example_meaning, meaning, mod_date, reg_date) VALUES (1, 'I''m sure that ~', 'I''m sure that I will achieve my goal.', '난 내 목표를 달성할 거라고 확신해.', '~라는 것을 확신해', '2021-05-29 14:21:12', '2021-05-29 14:21:09');
 INSERT INTO useful_expression (exp_id, expression, expression_example, expression_example_meaning, meaning, mod_date, reg_date) VALUES (2, 'I''m happy to ~', 'I''m happy to see you again.', '널 다시 보게 돼서 기뻐.', '~해서 기뻐', '2021-05-29 14:21:49', '2021-05-29 14:21:48');
@@ -7,3 +41,15 @@ INSERT INTO useful_expression (exp_id, expression, expression_example, expressio
 
 INSERT INTO today_useful_expression (id, exp_id, mod_date, reg_date) VALUES (1, 1, '2021-05-29 14:21:12', '2021-05-29 14:21:09');
 INSERT INTO today_useful_expression (id, exp_id, mod_date, reg_date) VALUES (2, 2, '2021-05-29 14:21:12', '2021-05-29 14:21:09');
+
+INSERT INTO member_scrap (exp_id, member_id, reg_date) VALUES (2, 1, '2021-06-20 18:53:24.110939');
+INSERT INTO member_scrap (exp_id, member_id, reg_date) VALUES (3, 1, '2021-07-08 11:30:31.503929');
+INSERT INTO member_scrap (exp_id, member_id, reg_date) VALUES (1, 2, '2021-06-21 00:04:21.890788');
+
+INSERT INTO badge (badge_id, content, name) VALUES (1, '머렝 3일입니다.', '머렝 3일');
+INSERT INTO badge (badge_id, content, name) VALUES (2, '셀럽 머렝입니다.', '셀럽 머렝');
+INSERT INTO badge (badge_id, content, name) VALUES (3, '학구정 머렝입니다.', '학구적 머렝');
+INSERT INTO badge (badge_id, content, name) VALUES (4, '머렝 셋입니다.', '머렝 셋');
+
+INSERT INTO badge_accomplished (badge_id, member_id, reg_date, is_checked) VALUES (1, 1, '2021-07-08 11:13:51.113911', false);
+INSERT INTO badge_accomplished (badge_id, member_id, reg_date, is_checked) VALUES (2, 1, '2021-07-08 11:13:51.113911', false);


### PR DESCRIPTION
- 기존 mockbean을 사용하던 controller test를 통합 테스트로서 활용
    - mockbean 가능한 한 제거(random, 외부 api 호출 등 통제 불가능한 요소는 제외)
    - sql 어노테이션 활용하여 실제 데이터를 테스트시 셋팅할 수 있도록 설정