### PR TITLE
[리팩토링] 엔티티 매퍼 리팩토링

### DIFF
--- a/mureng-api/src/main/java/net/mureng/api/core/component/EntityMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/core/component/EntityMapper.java
@@ -1,6 +1,0 @@
-package net.mureng.api.core.component;
-
-public interface EntityMapper<ENTITY, DTO> {
-    DTO toDto(ENTITY entity);
-    ENTITY toEntity(DTO dto);
-}

--- a/mureng-api/src/main/java/net/mureng/api/member/component/MemberAchievementMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/component/MemberAchievementMapper.java
@@ -13,10 +13,6 @@ import java.util.List;
 public interface MemberAchievementMapper {
 
     @Mapping(target = "requesterProfile", expression = "java(member.isRequesterProfile(loggedInMember.getMemberId()))")
-    @Mapping(target = "accomplishedBadge", ignore = true)
-    MemberAchievementDto toDto(Member member, List<Badge> badges, Member loggedInMember);
-
-    @Mapping(target = "requesterProfile", expression = "java(member.isRequesterProfile(loggedInMember.getMemberId()))")
     @Mapping(target = "accomplishedBadge", expression = "java(isCelebrityMurengAccomplished && member.isRequesterProfile(loggedInMember.getMemberId()) ? 2L : 0L)")
     MemberAchievementDto toDto(Member member, List<Badge> badges, Member loggedInMember, boolean isCelebrityMurengAccomplished);
 }

--- a/mureng-api/src/main/java/net/mureng/api/member/component/MemberMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/component/MemberMapper.java
@@ -4,10 +4,14 @@ import net.mureng.api.member.dto.MemberDto;
 import net.mureng.core.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
 
 import java.time.format.DateTimeFormatter;
 
-@Mapper(componentModel = "spring", imports = DateTimeFormatter.class)
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = DateTimeFormatter.class)
 public interface MemberMapper {
     @Mapping(target = "murengCount", expression = "java(member.getMurengCookies().isEmpty() ? 0 : member.getMurengCookies().size())")
     @Mapping(target = "attendanceCount", expression = "java(member.getMemberAttendance().getAttendanceCount())")
@@ -15,12 +19,5 @@ public interface MemberMapper {
             ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")) )")
     MemberDto.ReadOnly toDto(Member member);
 
-    @Mapping(target = "memberId", ignore = true)
-    @Mapping(target = "isActive", ignore = true)
-    @Mapping(target = "memberSetting", ignore = true)
-    @Mapping(target = "memberAttendance", ignore = true)
-    @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "modDate", ignore = true)
-    @Mapping(target = "murengCookies", ignore = true)
     Member toEntity(MemberDto memberDto);
 }

--- a/mureng-api/src/main/java/net/mureng/api/member/component/MemberMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/component/MemberMapper.java
@@ -1,6 +1,5 @@
 package net.mureng.api.member.component;
 
-import net.mureng.api.core.component.EntityMapper;
 import net.mureng.api.member.dto.MemberDto;
 import net.mureng.core.member.entity.Member;
 import org.mapstruct.Mapper;
@@ -9,15 +8,13 @@ import org.mapstruct.Mapping;
 import java.time.format.DateTimeFormatter;
 
 @Mapper(componentModel = "spring", imports = DateTimeFormatter.class)
-public interface MemberMapper extends EntityMapper<Member, MemberDto> {
-    @Override
+public interface MemberMapper {
     @Mapping(target = "murengCount", expression = "java(member.getMurengCookies().isEmpty() ? 0 : member.getMurengCookies().size())")
     @Mapping(target = "attendanceCount", expression = "java(member.getMemberAttendance().getAttendanceCount())")
     @Mapping(target = "lastAttendanceDate", expression = "java(member.getMemberAttendance().getLastAttendanceDate()" +
             ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")) )")
     MemberDto.ReadOnly toDto(Member member);
 
-    @Override
     @Mapping(target = "memberId", ignore = true)
     @Mapping(target = "isActive", ignore = true)
     @Mapping(target = "memberSetting", ignore = true)

--- a/mureng-api/src/main/java/net/mureng/api/member/web/MemberScrapController.java
+++ b/mureng-api/src/main/java/net/mureng/api/member/web/MemberScrapController.java
@@ -11,6 +11,7 @@ import net.mureng.api.member.component.MemberScrapMapper;
 import net.mureng.api.member.dto.MemberScrapDto;
 import net.mureng.api.member.service.MemberExpressionScrapService;
 import net.mureng.api.todayexpression.component.TodayExpressionMapper;
+import net.mureng.api.todayexpression.component.TodayExpressionWithBadgeMapper;
 import net.mureng.api.todayexpression.dto.TodayExpressionDto;
 import net.mureng.core.badge.service.BadgeAccomplishedService;
 import net.mureng.core.member.entity.Member;
@@ -28,9 +29,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 public class MemberScrapController {
-    private final MemberExpressionScrapService memberExpressionScrapService;
-    private final TodayExpressionMapper todayExpressionMapper;
     private final MemberScrapMapper memberScrapMapper;
+    private final TodayExpressionWithBadgeMapper todayExpressionWithBadgeMapper;
+
+    private final MemberExpressionScrapService memberExpressionScrapService;
     private final MemberService memberService;
     private final BadgeAccomplishedService badgeAccomplishedService;
 
@@ -38,7 +40,7 @@ public class MemberScrapController {
     @PostMapping("/scrap/{expId}")
     public ResponseEntity<ApiResult<TodayExpressionDto>> scrap(@CurrentUser Member member, @PathVariable Long expId){
         return ResponseEntity.ok(ApiResult.ok(
-                todayExpressionMapper.toDto(
+                todayExpressionWithBadgeMapper.toDto(
                     memberExpressionScrapService.scrapTodayExpression(member, expId).getTodayExpression(), member,
                         badgeAccomplishedService.createAcademicMureng(member.getMemberId())
                 )

--- a/mureng-api/src/main/java/net/mureng/api/question/component/QuestionMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/question/component/QuestionMapper.java
@@ -6,15 +6,16 @@ import net.mureng.api.question.dto.QuestionDto;
 import net.mureng.core.question.entity.Question;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring", uses = { WordHintMapper.class, MemberMapper.class })
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = { WordHintMapper.class, MemberMapper.class })
 public interface QuestionMapper {
     @Mapping(target = "repliesCount", expression = "java(question.getReplies().size())")
     QuestionDto.ReadOnly toDto(Question question);
 
-    @Mapping(target = "questionId", ignore = true)
     @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "replies", ignore = true)
-    @Mapping(target = "wordHints", ignore = true)
     Question toEntity(QuestionDto questionDto, Member author);
 }

--- a/mureng-api/src/main/java/net/mureng/api/question/component/QuestionMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/question/component/QuestionMapper.java
@@ -1,6 +1,5 @@
 package net.mureng.api.question.component;
 
-import net.mureng.api.core.component.EntityMapper;
 import net.mureng.api.member.component.MemberMapper;
 import net.mureng.core.member.entity.Member;
 import net.mureng.api.question.dto.QuestionDto;
@@ -9,18 +8,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = { WordHintMapper.class, MemberMapper.class })
-public interface QuestionMapper extends EntityMapper<Question, QuestionDto> {
-    @Override
+public interface QuestionMapper {
     @Mapping(target = "repliesCount", expression = "java(question.getReplies().size())")
     QuestionDto.ReadOnly toDto(Question question);
-
-    @Override
-    @Mapping(target = "questionId", ignore = true)
-    @Mapping(target = "author", ignore = true)
-    @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "replies", ignore = true)
-    @Mapping(target = "wordHints", ignore = true)
-    Question toEntity(QuestionDto questionDto);
 
     @Mapping(target = "questionId", ignore = true)
     @Mapping(target = "regDate", ignore = true)

--- a/mureng-api/src/main/java/net/mureng/api/question/component/WordHintMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/question/component/WordHintMapper.java
@@ -4,13 +4,13 @@ import net.mureng.api.question.dto.WordHintDto;
 import net.mureng.core.question.entity.WordHint;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface WordHintMapper {
     WordHintDto.ReadOnly toDto(WordHint wordHint);
 
-    @Mapping(target = "hintId", ignore = true)
-    @Mapping(target = "question", ignore = true)
-    @Mapping(target = "regDate", ignore = true)
     WordHint toEntity(WordHintDto wordHintDto);
 }

--- a/mureng-api/src/main/java/net/mureng/api/question/component/WordHintMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/question/component/WordHintMapper.java
@@ -1,17 +1,14 @@
 package net.mureng.api.question.component;
 
-import net.mureng.api.core.component.EntityMapper;
 import net.mureng.api.question.dto.WordHintDto;
 import net.mureng.core.question.entity.WordHint;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
-public interface WordHintMapper extends EntityMapper<WordHint, WordHintDto> {
-    @Override
+public interface WordHintMapper {
     WordHintDto.ReadOnly toDto(WordHint wordHint);
 
-    @Override
     @Mapping(target = "hintId", ignore = true)
     @Mapping(target = "question", ignore = true)
     @Mapping(target = "regDate", ignore = true)

--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
@@ -1,6 +1,5 @@
 package net.mureng.api.reply.component;
 
-import net.mureng.api.core.component.EntityMapper;
 import net.mureng.api.member.component.MemberMapper;
 import net.mureng.api.reply.dto.ReplyLikesDto;
 import net.mureng.core.reply.entity.ReplyLikes;
@@ -9,15 +8,13 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = { ReplyMapper.class, MemberMapper.class })
-public interface ReplyLikesMapper extends EntityMapper<ReplyLikes, ReplyLikesDto> {
+public interface ReplyLikesMapper {
 
-    @Override
     @Mapping(source = "replyLikes.member.memberId", target = "memberId")
     @Mapping(source = "replyLikes.reply.replyId", target = "replyId")
     @Mapping(target = "likes", ignore = true)
     ReplyLikesDto toDto(ReplyLikes replyLikes);
 
-    @Override
     @BeanMapping(ignoreByDefault = true)
     ReplyLikes toEntity(ReplyLikesDto replyLikesDto);
 }

--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyLikesMapper.java
@@ -3,18 +3,14 @@ package net.mureng.api.reply.component;
 import net.mureng.api.member.component.MemberMapper;
 import net.mureng.api.reply.dto.ReplyLikesDto;
 import net.mureng.core.reply.entity.ReplyLikes;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 
-@Mapper(componentModel = "spring", uses = { ReplyMapper.class, MemberMapper.class })
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = { ReplyMapper.class, MemberMapper.class })
 public interface ReplyLikesMapper {
 
     @Mapping(source = "replyLikes.member.memberId", target = "memberId")
     @Mapping(source = "replyLikes.reply.replyId", target = "replyId")
-    @Mapping(target = "likes", ignore = true)
     ReplyLikesDto toDto(ReplyLikes replyLikes);
-
-    @BeanMapping(ignoreByDefault = true)
-    ReplyLikes toEntity(ReplyLikesDto replyLikesDto);
 }

--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyMapper.java
@@ -1,28 +1,17 @@
 package net.mureng.api.reply.component;
 
-import net.mureng.api.core.component.EntityMapper;
 import net.mureng.api.member.component.MemberMapper;
 import net.mureng.api.question.component.QuestionMapper;
 import net.mureng.api.reply.dto.ReplyDto;
 import net.mureng.core.member.entity.Member;
 import net.mureng.core.question.entity.Question;
 import net.mureng.core.reply.entity.Reply;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.NullValueMappingStrategy;
-import org.mapstruct.ReportingPolicy;
+import org.mapstruct.*;
 
-@Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class }, unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
-    @Override
-    @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
-    @Mapping(target = "questionId", expression = "java(reply.getQuestion().getQuestionId())")
-    @Mapping(target = "requestedByAuthor", ignore = true)
-    @Mapping(target = "likedByRequester", ignore = true)
-    @Mapping(target = "accomplishedBadge", ignore = true)
-    ReplyDto.ReadOnly toDto(Reply reply);
+import static org.mapstruct.NullValueCheckStrategy.ALWAYS;
 
+@Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class })
+public interface ReplyMapper {
     @Mapping(target = "image", source = "reply.image")
     @Mapping(target = "regDate", source = "reply.regDate")
     @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
@@ -31,26 +20,6 @@ public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
     @Mapping(target = "likedByRequester", expression = "java(reply.likedByRequester(loggedInMember))")
     @Mapping(target = "accomplishedBadge", ignore = true)
     ReplyDto.ReadOnly toDto(Reply reply, Member loggedInMember);
-
-    @Mapping(target = "image", source = "reply.image")
-    @Mapping(target = "regDate", source = "reply.regDate")
-    @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
-    @Mapping(target = "questionId", expression = "java(reply.getQuestion().getQuestionId())")
-    @Mapping(target = "requestedByAuthor", expression = "java(reply.isAuthor(loggedInMember))")
-    @Mapping(target = "likedByRequester", expression = "java(reply.likedByRequester(loggedInMember))")
-    @Mapping(target = "accomplishedBadge", expression = "java(isMureng3DaysAccomplished == true ? 1L : isMurengSetAccomplished == true ? 4L : 0L)")
-    ReplyDto.ReadOnly toDto(Reply reply, Member loggedInMember, boolean isMureng3DaysAccomplished, boolean isMurengSetAccomplished);
-
-    @Override
-    @Mapping(target = "replyId", ignore = true)
-    @Mapping(target = "author", ignore = true)
-    @Mapping(target = "question", ignore = true)
-    @Mapping(target = "visible", ignore = true)
-    @Mapping(target = "deleted", ignore = true)
-    @Mapping(target = "modDate", ignore = true)
-    @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "replyLikes", ignore = true)
-    Reply toEntity(ReplyDto replyDto);
 
     @Mapping(target = "replyId", ignore = true)
     @Mapping(target = "visible", ignore = true)
@@ -62,7 +31,7 @@ public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
     @Mapping(target = "content", expression = "java(replyDto.getContent())")
     @Mapping(target = "question", source = "question")
     @Mapping(target = "author", source = "author")
-    Reply toEntity(ReplyDto replyDto, Member author, Question question);
+    Reply toEntityForPost(ReplyDto replyDto, Member author, Question question);
 
     @Mapping(target = "question", ignore = true)
     @Mapping(target = "visible", ignore = true)
@@ -70,6 +39,7 @@ public interface ReplyMapper extends EntityMapper<Reply, ReplyDto> {
     @Mapping(target = "modDate", ignore = true)
     @Mapping(target = "regDate", ignore = true)
     @Mapping(target = "replyLikes", ignore = true)
+    @Mapping(target = "author", source = "author")
     @Mapping(target = "image", expression = "java(replyDto.getImage())")
-    Reply toEntity(ReplyDto replyDto, Member author, Long replyId);
+    Reply toEntityForPut(ReplyDto replyDto, Member author, Long replyId);
 }

--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyMapper.java
@@ -10,35 +10,31 @@ import org.mapstruct.*;
 
 import static org.mapstruct.NullValueCheckStrategy.ALWAYS;
 
-@Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class })
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = { QuestionMapper.class, MemberMapper.class })
 public interface ReplyMapper {
+
     @Mapping(target = "image", source = "reply.image")
     @Mapping(target = "regDate", source = "reply.regDate")
     @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
     @Mapping(target = "questionId", expression = "java(reply.getQuestion().getQuestionId())")
     @Mapping(target = "requestedByAuthor", expression = "java(reply.isAuthor(loggedInMember))")
     @Mapping(target = "likedByRequester", expression = "java(reply.likedByRequester(loggedInMember))")
-    @Mapping(target = "accomplishedBadge", ignore = true)
     ReplyDto.ReadOnly toDto(Reply reply, Member loggedInMember);
 
-    @Mapping(target = "replyId", ignore = true)
-    @Mapping(target = "visible", ignore = true)
-    @Mapping(target = "deleted", ignore = true)
+
     @Mapping(target = "modDate", ignore = true)
     @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "replyLikes", ignore = true)
-    @Mapping(target = "image", expression = "java(replyDto.getImage())")
-    @Mapping(target = "content", expression = "java(replyDto.getContent())")
     @Mapping(target = "question", source = "question")
     @Mapping(target = "author", source = "author")
+    @Mapping(target = "image", expression = "java(replyDto.getImage())")
+    @Mapping(target = "content", expression = "java(replyDto.getContent())")
     Reply toEntityForPost(ReplyDto replyDto, Member author, Question question);
 
-    @Mapping(target = "question", ignore = true)
-    @Mapping(target = "visible", ignore = true)
-    @Mapping(target = "deleted", ignore = true)
+
     @Mapping(target = "modDate", ignore = true)
     @Mapping(target = "regDate", ignore = true)
-    @Mapping(target = "replyLikes", ignore = true)
     @Mapping(target = "author", source = "author")
     @Mapping(target = "image", expression = "java(replyDto.getImage())")
     Reply toEntityForPut(ReplyDto replyDto, Member author, Long replyId);

--- a/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyWithBadgeMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/component/ReplyWithBadgeMapper.java
@@ -1,0 +1,21 @@
+package net.mureng.api.reply.component;
+
+import net.mureng.api.member.component.MemberMapper;
+import net.mureng.api.question.component.QuestionMapper;
+import net.mureng.api.reply.dto.ReplyDto;
+import net.mureng.core.member.entity.Member;
+import net.mureng.core.reply.entity.Reply;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = { QuestionMapper.class, MemberMapper.class })
+public interface ReplyWithBadgeMapper {
+    @Mapping(target = "image", source = "reply.image")
+    @Mapping(target = "regDate", source = "reply.regDate")
+    @Mapping(target = "replyLikeCount", expression = "java(reply.getReplyLikes().size())")
+    @Mapping(target = "questionId", expression = "java(reply.getQuestion().getQuestionId())")
+    @Mapping(target = "requestedByAuthor", expression = "java(reply.isAuthor(loggedInMember))")
+    @Mapping(target = "likedByRequester", expression = "java(reply.likedByRequester(loggedInMember))")
+    @Mapping(target = "accomplishedBadge", expression = "java(isMureng3DaysAccomplished == true ? 1L : isMurengSetAccomplished == true ? 4L : 0L)")
+    ReplyDto.ReadOnly toDto(Reply reply, Member loggedInMember, boolean isMureng3DaysAccomplished, boolean isMurengSetAccomplished);
+}

--- a/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyController.java
+++ b/mureng-api/src/main/java/net/mureng/api/reply/web/ReplyController.java
@@ -10,6 +10,7 @@ import net.mureng.api.core.annotation.CurrentUser;
 import net.mureng.api.core.dto.ApiPageRequest;
 import net.mureng.api.core.dto.ApiPageResult;
 import net.mureng.api.core.dto.ApiResult;
+import net.mureng.api.reply.component.ReplyWithBadgeMapper;
 import net.mureng.api.reply.service.ReplyPaginationService;
 import net.mureng.core.badge.service.BadgeAccomplishedService;
 import net.mureng.core.member.entity.Member;
@@ -31,6 +32,8 @@ import javax.validation.constraints.NotNull;
 @RequestMapping("/api/reply")
 public class ReplyController {
     private final ReplyMapper replyMapper;
+    private final ReplyWithBadgeMapper replyWithBadgeMapper;
+
     private final ReplyService replyService;
     private final ReplyPaginationService replyPaginationService;
     private final BadgeAccomplishedService badgeAccomplishedService;
@@ -59,9 +62,9 @@ public class ReplyController {
     @PostMapping
     public ResponseEntity<ApiResult<ReplyDto.ReadOnly>> create(@CurrentUser Member member,
                                                                @RequestBody @Valid ReplyDto replyDto){
-            Reply newReply = replyMapper.toEntity(replyDto, member, Question.builder().questionId(replyDto.getQuestionId()).build());
+            Reply newReply = replyMapper.toEntityForPost(replyDto, member, Question.builder().questionId(replyDto.getQuestionId()).build());
 
-            return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
+            return ResponseEntity.ok(ApiResult.ok(replyWithBadgeMapper.toDto(
                 replyService.create(newReply), member,
                     badgeAccomplishedService.createMureng3Days(member.getMemberId()),
                     badgeAccomplishedService.createMurengSet(member.getMemberId())
@@ -74,7 +77,7 @@ public class ReplyController {
                                                                @RequestBody @Valid ReplyDto replyDto,
                                                                @PathVariable @NotNull Long replyId){
 
-        Reply newReply = replyMapper.toEntity(replyDto, member, replyId);
+        Reply newReply = replyMapper.toEntityForPut(replyDto, member, replyId);
 
         return ResponseEntity.ok(ApiResult.ok(replyMapper.toDto(
                 replyService.update(newReply), member

--- a/mureng-api/src/main/java/net/mureng/api/todayexpression/component/TodayExpressionWithBadgeMapper.java
+++ b/mureng-api/src/main/java/net/mureng/api/todayexpression/component/TodayExpressionWithBadgeMapper.java
@@ -8,9 +8,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
-public interface TodayExpressionMapper {
+public interface TodayExpressionWithBadgeMapper {
     @Mapping(target = "scrappedByRequester", expression = "java(todayExpression.scrappedByRequester(loggedInMember))")
-    @Mapping(target = "accomplishedBadge", ignore = true)
-    TodayExpressionDto toDto(TodayExpression todayExpression, @Context Member loggedInMember);
-
+    @Mapping(target = "accomplishedBadge", expression = "java(isAcademicMurengAccomplished == true ? 3L : 0L)")
+    TodayExpressionDto toDto(TodayExpression todayExpression, @Context Member loggedInMember, Boolean isAcademicMurengAccomplished);
 }

--- a/mureng-api/src/test/java/net/mureng/api/member/component/MemberAchievementMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/member/component/MemberAchievementMapperTest.java
@@ -32,16 +32,6 @@ public class MemberAchievementMapperTest {
     private static final MemberDto memberDto = DtoCreator.createMemberDto();
 
     @Test
-    public void 엔티티에서_DTO변환_테스트() {
-        MemberAchievementDto mappedDto = memberAchievementMapper.toDto(member, badges, member);
-
-        assertEquals(mappedDto.getMember().getEmail(), memberDto.getEmail());
-        assertEquals(mappedDto.getBadges().size(), badgeDtos.size());
-        assertEquals(mappedDto.getBadges().get(0).getName(), badgeDtos.get(0).getName());
-        assertTrue(mappedDto.isRequesterProfile());
-    }
-
-    @Test
     public void 엔티티에서_DTO변환_테스트_뱃지획득() {
         MemberAchievementDto mappedDto = memberAchievementMapper.toDto(member, badges, member, true);
 

--- a/mureng-api/src/test/java/net/mureng/api/question/component/QuestionMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/question/component/QuestionMapperTest.java
@@ -73,16 +73,6 @@ class QuestionMapperTest {
     }
 
     @Test
-    public void DTO에서_엔티티변환_테스트() {
-        Question mappedEntity = questionMapper.toEntity(questionDto);
-//        assertEquals(question.getQuestionId(), mappedEntity.getQuestionId());
-        assertEquals(question.getCategory(), mappedEntity.getCategory());
-        assertEquals(question.getContent(), mappedEntity.getContent());
-        assertEquals(question.getKoContent(), mappedEntity.getKoContent());
-//        assertEquals(question.getWordHints().size(), mappedEntity.getWordHints().size());
-    }
-
-    @Test
     public void DTO에서_엔티티_사용자추가_변환_테스트() {
         Question mappedEntity = questionMapper.toEntity(questionDto, EntityCreator.createMemberEntity());
         assertEquals(question.getCategory(), mappedEntity.getCategory());

--- a/mureng-api/src/test/java/net/mureng/api/reply/component/ReplyMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/reply/component/ReplyMapperTest.java
@@ -17,22 +17,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ReplyMapperTest {
 
     @Autowired
-    ReplyMapper replyMapper;
+    private ReplyMapper replyMapper;
+
+    @Autowired
+    private ReplyWithBadgeMapper replyWithBadgeMapper;
 
     private final Reply reply = EntityCreator.createReplyEntity();
     private final ReplyDto.ReadOnly replyDto = DtoCreator.createReplyDto();
-
-    @Test
-    public void 엔티티에서_DTO변환_테스트() {
-        ReplyDto.ReadOnly mappedDto = replyMapper.toDto(reply);
-        assertEquals(replyDto.getReplyId(), mappedDto.getReplyId());
-        assertEquals(replyDto.getContent(), mappedDto.getContent());
-        assertEquals(replyDto.getAuthor().getMemberId(), mappedDto.getAuthor().getMemberId());
-        assertEquals(replyDto.getQuestion().getQuestionId(), mappedDto.getQuestion().getQuestionId());
-        assertEquals(replyDto.getReplyLikeCount(), mappedDto.getReplyLikeCount());
-        assertNull(mappedDto.getRequestedByAuthor());
-        assertNull(mappedDto.getLikedByRequester());
-    }
 
     @Test
     public void 엔티티에서_DTO변환_로그인사용자_테스트() {
@@ -48,7 +39,7 @@ class ReplyMapperTest {
 
     @Test
     public void 엔티티에서_DTO변환_로그인사용자_테스트_뱃지획득() {
-        ReplyDto.ReadOnly mappedDto = replyMapper.toDto(reply, EntityCreator.createMemberEntity(), false, true);
+        ReplyDto.ReadOnly mappedDto = replyWithBadgeMapper.toDto(reply, EntityCreator.createMemberEntity(), false, true);
         assertEquals(replyDto.getReplyId(), mappedDto.getReplyId());
         assertEquals(replyDto.getContent(), mappedDto.getContent());
         assertEquals(replyDto.getAuthor().getMemberId(), mappedDto.getAuthor().getMemberId());
@@ -60,15 +51,8 @@ class ReplyMapperTest {
     }
 
     @Test
-    public void DTO에서_엔티티변환_테스트() {
-        Reply mappedEntity = replyMapper.toEntity(replyDto);
-        assertEquals(reply.getContent(), mappedEntity.getContent());
-        assertEquals(reply.getImage(), mappedEntity.getImage());
-    }
-
-    @Test
     public void DTO에서_엔티티변환_답변생성할때_테스트() {
-        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), Question.builder().questionId(replyDto.getQuestionId()).build());
+        Reply mappedEntity = replyMapper.toEntityForPost(replyDto, EntityCreator.createMemberEntity(), Question.builder().questionId(replyDto.getQuestionId()).build());
         assertEquals(replyDto.getQuestionId(), mappedEntity.getQuestion().getQuestionId());
         assertEquals(reply.getContent(), mappedEntity.getContent());
         assertEquals(reply.getAuthor().getEmail(), mappedEntity.getAuthor().getEmail());
@@ -76,7 +60,7 @@ class ReplyMapperTest {
 
     @Test
     public void DTO에서_엔티티변환_답변수정할때_테스트() {
-        Reply mappedEntity = replyMapper.toEntity(replyDto, EntityCreator.createMemberEntity(), 2L);
+        Reply mappedEntity = replyMapper.toEntityForPut(replyDto, EntityCreator.createMemberEntity(), 2L);
         assertEquals(2L, mappedEntity.getReplyId());
         assertEquals(reply.getContent(), mappedEntity.getContent());
         assertEquals(reply.getAuthor().getEmail(), mappedEntity.getAuthor().getEmail());

--- a/mureng-api/src/test/java/net/mureng/api/todayexpression/component/TodayExpressionMapperTest.java
+++ b/mureng-api/src/test/java/net/mureng/api/todayexpression/component/TodayExpressionMapperTest.java
@@ -19,6 +19,9 @@ public class TodayExpressionMapperTest {
     @Autowired
     private TodayExpressionMapper todayExpressionMapper;
 
+    @Autowired
+    private TodayExpressionWithBadgeMapper todayExpressionWithBadgeMapper;
+
     private final TodayExpression todayExpression = EntityCreator.createTodayExpressionEntity();
     private final TodayExpressionDto todayExpressionDto = DtoCreator.createTodayExpressionDto();
 
@@ -37,7 +40,7 @@ public class TodayExpressionMapperTest {
 
     @Test
     public void 엔티티에서_DTO변환_테스트_뱃지획득() {
-        TodayExpressionDto mappedDto = todayExpressionMapper.toDto(todayExpression, member, true);
+        TodayExpressionDto mappedDto = todayExpressionWithBadgeMapper.toDto(todayExpression, member, true);
         assertEquals(todayExpressionDto.getExpId(), mappedDto.getExpId());
         assertEquals(todayExpressionDto.getExpression(), mappedDto.getExpression());
         assertEquals(todayExpressionDto.getMeaning(), mappedDto.getMeaning());


### PR DESCRIPTION
- 매퍼 인터페이스 분류
- 동일한 인터페이스 내에 동일한 이름의 메서드인 경우, 상황에 맞게 메서드명 변경
- `ignore = true`를 줄일 수 있도록, unmappedTargetPolicy 설정
- 다만 regDate 혹은 modDate와 같이, 리턴하려는 엔티티(ex: Reply)와 인자로 제공한 엔티티(ex: Member)에 동일한 속성이 있을 경우, `ignore = true`를 설정해줘야 함. 만약 하지 않을 시, `Reply.regDate = Member.regDate`와 같이 설정되는 문제가 생김